### PR TITLE
update ethlint-pre-commit to a non-broken version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       language_version: python3.6
 
 -   repo: git://github.com/pre-commit/pre-commit-hooks
-    sha: v2.0.0
+    rev: v2.0.0
     hooks:
     - id: check-added-large-files
     - id: check-ast
@@ -28,7 +28,8 @@ repos:
     - id: no-commit-to-branch
       args: [--branch, develop, --branch, master]
 -   repo: https://github.com/schmir/ethlint-pre-commit.git
-    rev: 'fc4f655fe2ad22a6f3668045a99b5cc1b21f79da'
+    rev: 'ceedc72aa232b9391840256c7781226a3e238b1a'
     hooks:
     - id: ethlint
-      args: ["--config", "contracts/.soliumrc"]
+      exclude: ^contracts/contracts/lib/.*\.sol$
+      args: ["--config", "contracts/.soliumrc.json"]


### PR DESCRIPTION
The old version didn't check all of the files supplied as arguments by
pre-commit.

Also ignore solidity files in lib.