### PR TITLE
Extend deposit locker slashing to burn deposit

### DIFF
--- a/contracts/contracts/DepositLocker.sol
+++ b/contracts/contracts/DepositLocker.sol
@@ -111,6 +111,7 @@ contract DepositLocker is DepositLockerInterface, Ownable {
         require(msg.sender == slasher, "Only the slasher can call this function.");
         require(canWithdraw[_depositorToBeSlashed], "cannot slash address");
         canWithdraw[_depositorToBeSlashed] = false;
+        address(0).transfer(valuePerDepositor);
         emit Slash(_depositorToBeSlashed, valuePerDepositor);
         return true;
     }

--- a/contracts/tests/conftest.py
+++ b/contracts/tests/conftest.py
@@ -251,3 +251,12 @@ def send_ether_to_whitelisted_accounts(chain, whitelist):
 def add_whitelist_to_validator_auction_contract(contract, whitelist):
     contract.functions.addToWhitelist(whitelist).transact()
     return contract
+
+
+@pytest.fixture()
+def block_reward_amount(chain, web3):
+    mining_reward_address = "0x0000000000000000000000000000000000000000"
+    balance_before = web3.eth.getBalance(mining_reward_address)
+    chain.mine_block()
+    balance_after = web3.eth.getBalance(mining_reward_address)
+    return balance_after - balance_before

--- a/contracts/tests/test_deposit_locker.py
+++ b/contracts/tests/test_deposit_locker.py
@@ -244,10 +244,15 @@ def testenv(deploy_contract, accounts, web3):
 
 
 @pytest.fixture()
-def testenv_deposited(testenv):
+def value_per_depositor():
+    return 1000
+
+
+@pytest.fixture()
+def testenv_deposited(testenv, value_per_depositor):
     """return a test environment, with all depositors registered and the deposit already made"""
     testenv.register_all_depositors()
-    testenv.deposit(1000, len(testenv.depositors) * 1000)
+    testenv.deposit(value_per_depositor, len(testenv.depositors) * value_per_depositor)
     return testenv
 
 
@@ -353,11 +358,37 @@ def test_slash_from_non_slasher_throws(testenv):
         )
 
 
-def test_slash_after_deposit_works(testenv_deposited):
+def test_slash_after_deposit_works(
+    testenv_deposited, web3, value_per_depositor, block_reward_amount
+):
     depositor = testenv_deposited.depositors[0]
+    burn_address = "0x0000000000000000000000000000000000000000"
+    contract_address = testenv_deposited.deposit_locker.address
+
     assert testenv_deposited.can_withdraw(depositor)
-    testenv_deposited.slash(depositor)
+
+    burn_address_balance_before = web3.eth.getBalance(burn_address)
+    contract_address_balance_before = web3.eth.getBalance(contract_address)
+
+    # The burning address is in this testing scenario also the address getting
+    # the transaction fees and block rewards. To have a clear calculation make
+    # sure the transaction has no fees.
+    testenv_deposited.deposit_locker.functions.slash(depositor).transact(
+        {"from": testenv_deposited.slasher, "gasPrice": 0}
+    )
+
+    burn_address_balance_after = web3.eth.getBalance(burn_address)
+    contract_address_balance_after = web3.eth.getBalance(contract_address)
+
     assert not testenv_deposited.can_withdraw(depositor)
+    assert (
+        burn_address_balance_after
+        == burn_address_balance_before + value_per_depositor + block_reward_amount
+    )
+    assert (
+        contract_address_balance_after
+        == contract_address_balance_before - value_per_depositor
+    )
 
 
 def test_slash_twice_throws(testenv_deposited):


### PR DESCRIPTION
Closes #36 

Notes:
- Please mark that the zero address is the one to burn to as well as the mining address.
- Since it should be never possible to have not enough Ether on the contract to burn, I haven't add any further `require` checks. This wouldn't be even possible to test with the current setup I think.