### PR TITLE
make --release-block-number a required argument

### DIFF
--- a/auction-deploy/auction_deploy/cli.py
+++ b/auction-deploy/auction_deploy/cli.py
@@ -75,6 +75,7 @@ def main():
     "release_block_number",
     help="The release block number of the deposit locker",
     type=int,
+    required=True,
 )
 @keystore_option
 @gas_option


### PR DESCRIPTION
Otherwise `None` would be passed around as release_block_number, which would
make our code fail with a non obvious error message.