### PR TITLE
Add cli tool for whitelisting

### DIFF
--- a/auction-deploy/auction_deploy/cli.py
+++ b/auction-deploy/auction_deploy/cli.py
@@ -3,7 +3,6 @@ from enum import Enum
 import click
 from web3 import Web3, EthereumTesterProvider, Account
 from deploy_tools.deploy import send_function_call_transaction
-from eth_utils import is_address, to_checksum_address
 
 from auction_deploy.core import (
     deploy_auction_contracts,
@@ -14,17 +13,19 @@ from auction_deploy.core import (
     get_deployed_auction_contracts,
     whitelist_addresses,
     read_whitelist,
+    validate_and_format_address,
+    InvalidAddressException,
 )
 
 
 def validate_address(ctx, param, value):
     """This function must be at the top of click commands using it"""
-    if is_address(value):
-        return to_checksum_address(value)
-    else:
+    try:
+        return validate_and_format_address(value)
+    except InvalidAddressException as e:
         raise click.BadParameter(
             f"The address parameter is not recognized to be an address: {value}"
-        )
+        ) from e
 
 
 test_json_rpc = Web3(EthereumTesterProvider())

--- a/auction-deploy/auction_deploy/cli.py
+++ b/auction-deploy/auction_deploy/cli.py
@@ -1,4 +1,3 @@
-from pathlib import PosixPath
 from enum import Enum
 
 import click
@@ -13,6 +12,8 @@ from auction_deploy.core import (
     build_transaction_options,
     AuctionOptions,
     get_deployed_auction_contracts,
+    whitelist_addresses,
+    read_whitelist,
 )
 
 
@@ -46,7 +47,6 @@ jsonrpc_option = click.option(
     show_default=True,
     metavar="URL",
 )
-
 keystore_option = click.option(
     "--keystore",
     help="Path to the encrypted keystore",
@@ -123,7 +123,7 @@ def deploy(
     auction_duration: int,
     number_of_participants: int,
     release_block_number: int,
-    keystore: PosixPath,
+    keystore: str,
     jsonrpc: str,
     gas: int,
     gas_price: int,
@@ -185,14 +185,13 @@ def deploy(
 @jsonrpc_option
 def start_auction(
     auction_address,
-    keystore: PosixPath,
+    keystore: str,
     jsonrpc: str,
     gas: int,
     gas_price: int,
     nonce: int,
     auto_nonce: bool,
 ):
-
     web3 = connect_to_json_rpc(jsonrpc)
     private_key = retrieve_private_key(keystore)
     contracts = get_deployed_auction_contracts(web3, auction_address)
@@ -287,6 +286,73 @@ def print_auction_status(auction_address, jsonrpc):
     click.echo("The closing price is:                   " + str(closing_price))
 
 
+@main.command(short_help="Whitelists addresses for the auction")
+@click.option(
+    "--file",
+    help="Path to the csv file containing the addresses to be whitelisted",
+    type=click.Path(exists=True, dir_okay=False),
+    required=True,
+)
+@click.option(
+    "--auction-address",
+    help="Address of the auction contract",
+    callback=validate_address,
+    metavar="ADDRESS",
+    type=str,
+    required=True,
+)
+@click.option(
+    "--batch-size",
+    help="Number of addresses to be whitelisted within one transaction",
+    type=click.IntRange(min=1),
+    show_default=True,
+    default=100,
+)
+@keystore_option
+@gas_option
+@gas_price_option
+@nonce_option
+@auto_nonce_option
+@jsonrpc_option
+def whitelist(
+    file: str,
+    auction_address: str,
+    batch_size: int,
+    keystore: str,
+    jsonrpc: str,
+    gas: int,
+    gas_price: int,
+    nonce: int,
+    auto_nonce: bool,
+) -> None:
+
+    web3 = connect_to_json_rpc(jsonrpc)
+    whitelist = read_whitelist(file)
+    private_key = retrieve_private_key(keystore)
+
+    nonce = get_nonce(
+        web3=web3, nonce=nonce, auto_nonce=auto_nonce, private_key=private_key
+    )
+
+    transaction_options = build_transaction_options(
+        gas=gas, gas_price=gas_price, nonce=nonce
+    )
+
+    contracts = get_deployed_auction_contracts(web3, auction_address)
+
+    number_of_whitelisted_addresses = whitelist_addresses(
+        contracts.auction,
+        whitelist,
+        batch_size=batch_size,
+        web3=web3,
+        transaction_options=transaction_options,
+        private_key=private_key,
+    )
+    click.echo(
+        "Number of whitelisted addresses: " + str(number_of_whitelisted_addresses)
+    )
+
+
 def connect_to_json_rpc(jsonrpc) -> Web3:
     if jsonrpc == "test":
         web3 = test_json_rpc
@@ -295,20 +361,20 @@ def connect_to_json_rpc(jsonrpc) -> Web3:
     return web3
 
 
-def retrieve_private_key(keystore):
+def retrieve_private_key(keystore_path):
     """
     return the private key corresponding to keystore or none if keystore is none
     """
 
     private_key = None
 
-    if keystore is not None:
+    if keystore_path is not None:
         password = click.prompt(
             "Please enter the password to decrypt the keystore",
             type=str,
             hide_input=True,
         )
-        private_key = decrypt_private_key(str(keystore), password)
+        private_key = decrypt_private_key(keystore_path, password)
 
     return private_key
 

--- a/auction-deploy/auction_deploy/core.py
+++ b/auction-deploy/auction_deploy/core.py
@@ -5,7 +5,7 @@ from typing import Dict, NamedTuple, Sequence
 
 from web3.contract import Contract
 from eth_keyfile import extract_key_from_keyfile
-from eth_utils import is_checksum_address
+from eth_utils import is_address, to_checksum_address
 from deploy_tools.deploy import send_function_call_transaction, deploy_compiled_contract
 
 
@@ -225,13 +225,24 @@ def _filter_whitelisted_addresses(
     ]
 
 
+class InvalidAddressException(Exception):
+    pass
+
+
+def validate_and_format_address(address):
+    """Validates the address and formats it into the internal format
+    Will raise `InvalidAddressException, if the address is invalid"""
+    if is_address(address):
+        return to_checksum_address(address)
+    else:
+        raise InvalidAddressException()
+
+
 def read_whitelist(file_path: str):
     with open(file_path) as f:
         reader = csv.reader(f)
         addresses = []
         for line in reader:
-            address = line[0]
-            if not is_checksum_address(address):
-                raise ValueError("Invalid address in whitelist file")
+            address = validate_and_format_address(line[0])
             addresses.append(address)
         return addresses

--- a/auction-deploy/tests/conftest.py
+++ b/auction-deploy/tests/conftest.py
@@ -2,12 +2,17 @@ import json
 
 import pytest
 import eth_tester
+from eth_utils import to_canonical_address
 from eth_keyfile import create_keyfile_json
 
 # increase eth_tester's GAS_LIMIT
 # Otherwise we can't whitelist enough addresses for the validator auction in one transaction
 assert eth_tester.backends.pyevm.main.GENESIS_GAS_LIMIT < 8 * 10 ** 6
 eth_tester.backends.pyevm.main.GENESIS_GAS_LIMIT = 8 * 10 ** 6
+
+
+def create_address_string(i: int):
+    return f"0x{str(i).rjust(40, '0')}"
 
 
 @pytest.fixture()
@@ -44,3 +49,8 @@ def key_password():
 def private_key(account_keys):
     """private key of account[1]"""
     return account_keys[1]
+
+
+@pytest.fixture()
+def whitelist():
+    return [to_canonical_address(create_address_string(i)) for i in range(50)]


### PR DESCRIPTION
Add cli tool to read in a csv file(for now just list of addresses) with
addresses and add the diff of this list with the already whitelisted
addresses to the contract whitelist. The number of addresses within one
transaction is configurable

Fix some typings errors