### PR TITLE
Issue 64 release timestamp instead of blocknumber

### DIFF
--- a/auction-deploy/auction_deploy/cli.py
+++ b/auction-deploy/auction_deploy/cli.py
@@ -130,9 +130,9 @@ def main():
     default=123,
 )
 @click.option(
-    "--release-block",
-    "release_block_number",
-    help="The release block number of the deposit locker",
+    "--release-timestamp",
+    "release_timestamp",
+    help="The release timestamp of the deposit locker",
     type=int,
     required=True,
 )
@@ -146,7 +146,7 @@ def deploy(
     start_price: int,
     auction_duration: int,
     number_of_participants: int,
-    release_block_number: int,
+    release_timestamp: int,
     keystore: str,
     jsonrpc: str,
     gas: int,
@@ -162,7 +162,7 @@ def deploy(
         start_price * ETH_IN_WEI,
         auction_duration,
         number_of_participants,
-        release_block_number,
+        release_timestamp,
     )
 
     nonce = get_nonce(
@@ -183,7 +183,7 @@ def deploy(
         web3=web3,
         transaction_options=transaction_options,
         contracts=contracts,
-        release_block_number=release_block_number,
+        release_timestamp=release_timestamp,
         private_key=private_key,
     )
 

--- a/auction-deploy/auction_deploy/core.py
+++ b/auction-deploy/auction_deploy/core.py
@@ -13,7 +13,7 @@ class AuctionOptions(NamedTuple):
     start_price: int
     auction_duration: int
     number_of_participants: int
-    release_block_number: int
+    release_timestamp: int
 
 
 class DeployedAuctionContracts(NamedTuple):
@@ -122,14 +122,14 @@ def initialize_auction_contracts(
     web3,
     transaction_options=None,
     contracts: DeployedAuctionContracts,
-    release_block_number,
+    release_timestamp,
     private_key=None,
 ) -> None:
     if transaction_options is None:
         transaction_options = {}
 
     deposit_init = contracts.locker.functions.init(
-        release_block_number, contracts.slasher.address, contracts.auction.address
+        release_timestamp, contracts.slasher.address, contracts.auction.address
     )
     send_function_call_transaction(
         deposit_init,

--- a/auction-deploy/tests/test_cli.py
+++ b/auction-deploy/tests/test_cli.py
@@ -23,7 +23,7 @@ def deployed_auction_address(runner):
 
     deploy_result = runner.invoke(
         main,
-        args=f"deploy --release-block 789123 --participants {number_of_participants}"
+        args=f"deploy --release-timestamp 2000000000 --participants {number_of_participants}"
         f" --start-price {starting_price} --jsonrpc test",
     )
 
@@ -114,7 +114,7 @@ def test_cli_contract_parameters_set(runner):
 
     result = runner.invoke(
         main,
-        args="deploy --start-price 123 --duration 4 --participants 567 --release-block 789123 --jsonrpc test",
+        args="deploy --start-price 123 --duration 4 --participants 567 --release-timestamp 2000000000 --jsonrpc test",
     )
 
     assert result.exit_code == 0
@@ -123,7 +123,7 @@ def test_cli_contract_parameters_set(runner):
 def test_cli_transaction_parameters_set(runner):
     result = runner.invoke(
         main,
-        args="deploy --nonce 0 --gas-price 123456789 --gas 7000000 --release-block 789123 --jsonrpc test",
+        args="deploy --nonce 0 --gas-price 123456789 --gas 7000000 --release-timestamp 2000000000 --jsonrpc test",
     )
 
     assert result.exit_code == 0
@@ -133,7 +133,7 @@ def test_cli_private_key(runner, keystore_file_path, key_password):
 
     result = runner.invoke(
         main,
-        args="deploy --jsonrpc test --release-block 789123 --keystore "
+        args="deploy --jsonrpc test --release-timestamp 2000000000 --keystore "
         + str(keystore_file_path),
         input=key_password,
     )

--- a/contracts/contracts/DepositLocker.sol
+++ b/contracts/contracts/DepositLocker.sol
@@ -33,7 +33,7 @@ contract DepositLocker is DepositLockerInterface, Ownable {
 
     address public slasher;
     address public depositorsProxy;
-    uint public releaseBlockNumber;
+    uint public releaseTimestamp;
 
     mapping (address => bool) public canWithdraw;
     uint numberOfDepositors = 0;
@@ -66,13 +66,13 @@ contract DepositLocker is DepositLockerInterface, Ownable {
 
     function() external {}
 
-    function init(uint _releaseBlockNumber, address _slasher, address _depositorsProxy)
+    function init(uint _releaseTimestamp, address _slasher, address _depositorsProxy)
         external onlyOwner returns (bool _success)
     {
         require(!initialized, "The contract is already initialised.");
-        require(_releaseBlockNumber > block.number, "The release block number cannot be lower or equal to the current block number");
+        require(_releaseTimestamp > now, "The release timestamp must be in the future");
 
-        releaseBlockNumber = _releaseBlockNumber;
+        releaseTimestamp = _releaseTimestamp;
         slasher = _slasher;
         depositorsProxy = _depositorsProxy;
         initialized = true;
@@ -99,7 +99,7 @@ contract DepositLocker is DepositLockerInterface, Ownable {
     }
 
     function withdraw() public isInitialised isDeposited returns (bool _success) {
-        require(block.number >= releaseBlockNumber, "The deposit cannot be withdrawn yet.");
+        require(now >= releaseTimestamp, "The deposit cannot be withdrawn yet.");
         require(canWithdraw[msg.sender], "cannot withdraw from sender");
 
         canWithdraw[msg.sender] = false;

--- a/contracts/tests/deploy_util.py
+++ b/contracts/tests/deploy_util.py
@@ -19,13 +19,15 @@ def initialize_test_validator_slasher(deployed_contract, fund_contract_address, 
 
 def initialize_deposit_locker(
     deployed_contract,
-    block_number,
+    release_timestamp,
     validator_contract_address,
     auction_contract_address,
     web3,
 ):
     txid = deployed_contract.functions.init(
-        block_number, validator_contract_address, auction_contract_address
+        _releaseTimestamp=release_timestamp,
+        _slasher=validator_contract_address,
+        _depositorsProxy=auction_contract_address,
     ).transact({"from": web3.eth.defaultAccount})
     wait_for_successful_transaction_receipt(web3, txid)
     return deployed_contract


### PR DESCRIPTION
This implements https://github.com/trustlines-protocol/blockchain/issues/64

There's no date parsing yet, I will open another PR for that.