### PR TITLE
Extend validator set contract with historical data

### DIFF
--- a/contracts/contracts/TestValidatorSet.sol
+++ b/contracts/contracts/TestValidatorSet.sol
@@ -16,4 +16,26 @@ contract TestValidatorSet is ValidatorSet {
         return removeValidator(_validator);
     }
 
+    /**
+     * @dev Intended to test the functionality of finalizing the validator set
+     *      without the need to report a validator, which is the only opportunity to
+     *      change the set in the origin contract.
+     */
+    function testChangeValiatorSet(address[] _newValidatorSet) public {
+        require(finalized, "Validator set change is already ongoing!");
+        pendingValidators = _newValidatorSet;
+        initiateChange(_newValidatorSet);
+    }
+
+    /**
+     * @dev Allows the to finalize changes without the need to control the system
+     *      address. This enables testing independent from Parity.
+     */
+    function testFinalizeChange() public {
+        address originSystemAddress = systemAddress;
+        systemAddress = msg.sender;
+        finalizeChange();
+        systemAddress = originSystemAddress;
+    }
+
 }

--- a/contracts/contracts/ValidatorSet.sol
+++ b/contracts/contracts/ValidatorSet.sol
@@ -29,8 +29,8 @@ contract ValidatorSet {
     mapping(address => AddressStatus) status;
     bool public finalized;  // Was the last validator change finalized. Implies currentValidators == pendingValidators
     address public systemAddress = 0xffffFFFfFFffffffffffffffFfFFFfffFFFfFFfE;
-    uint[] public epochStartHeights;
-    mapping(uint => address[]) public epochStartToValidatorsMapping;
+    uint[] epochStartHeights;
+    mapping(uint => address[]) epochValidators;
 
     modifier onlySystem() {
         require(
@@ -69,12 +69,12 @@ contract ValidatorSet {
         return true;
     }
 
-    function getLengthOfEpochStartHeights() external view returns(uint) {
-        return epochStartHeights.length;
+    function getEpochStartHeights() external view returns(uint[]) {
+        return epochStartHeights;
     }
 
-    function getLengthOfEpochStartToValidatorsMapping(uint _blockNumber) external view returns(uint) {
-        return epochStartToValidatorsMapping[_blockNumber].length;
+    function getValidators(uint _epochStart) external view returns(address[]) {
+        return epochValidators[_epochStart];
     }
 
     /**
@@ -138,7 +138,7 @@ contract ValidatorSet {
         currentValidators = pendingValidators;
         finalized = true;
         epochStartHeights.push(block.number);
-        epochStartToValidatorsMapping[block.number] = currentValidators;
+        epochValidators[block.number] = currentValidators;
     }
 
     function removeValidator(address _validator) internal isFinalized returns (bool _success) {

--- a/contracts/contracts/ValidatorSet.sol
+++ b/contracts/contracts/ValidatorSet.sol
@@ -29,6 +29,8 @@ contract ValidatorSet {
     mapping(address => AddressStatus) status;
     bool public finalized;  // Was the last validator change finalized. Implies currentValidators == pendingValidators
     address public systemAddress = 0xffffFFFfFFffffffffffffffFfFFFfffFFFfFFfE;
+    uint[] public blockNumbersOfFinalizedChanges;
+    mapping(uint => address[]) public finalizedValidatorSets;
 
     modifier onlySystem() {
         require(
@@ -65,6 +67,14 @@ contract ValidatorSet {
         finalized = true;
         initiated = true;
         return true;
+    }
+
+    function getLengthOfBlockNumbersOfFinalizedChanges() external view returns(uint) {
+        return blockNumbersOfFinalizedChanges.length;
+    }
+
+    function getLengthOfFinalizedValidatorSet(uint _blockNumber) external view returns(uint) {
+        return finalizedValidatorSets[_blockNumber].length;
     }
 
     /**
@@ -127,6 +137,8 @@ contract ValidatorSet {
     function finalizeChange() public onlySystem {
         currentValidators = pendingValidators;
         finalized = true;
+        blockNumbersOfFinalizedChanges.push(block.number);
+        finalizedValidatorSets[block.number] = currentValidators;
     }
 
     function removeValidator(address _validator) internal isFinalized returns (bool _success) {

--- a/contracts/contracts/ValidatorSet.sol
+++ b/contracts/contracts/ValidatorSet.sol
@@ -29,8 +29,8 @@ contract ValidatorSet {
     mapping(address => AddressStatus) status;
     bool public finalized;  // Was the last validator change finalized. Implies currentValidators == pendingValidators
     address public systemAddress = 0xffffFFFfFFffffffffffffffFfFFFfffFFFfFFfE;
-    uint[] public blockNumbersOfFinalizedChanges;
-    mapping(uint => address[]) public finalizedValidatorSets;
+    uint[] public epochStartHeights;
+    mapping(uint => address[]) public epochStartToValidatorsMapping;
 
     modifier onlySystem() {
         require(
@@ -69,12 +69,12 @@ contract ValidatorSet {
         return true;
     }
 
-    function getLengthOfBlockNumbersOfFinalizedChanges() external view returns(uint) {
-        return blockNumbersOfFinalizedChanges.length;
+    function getLengthOfEpochStartHeights() external view returns(uint) {
+        return epochStartHeights.length;
     }
 
-    function getLengthOfFinalizedValidatorSet(uint _blockNumber) external view returns(uint) {
-        return finalizedValidatorSets[_blockNumber].length;
+    function getLengthOfEpochStartToValidatorsMapping(uint _blockNumber) external view returns(uint) {
+        return epochStartToValidatorsMapping[_blockNumber].length;
     }
 
     /**
@@ -137,8 +137,8 @@ contract ValidatorSet {
     function finalizeChange() public onlySystem {
         currentValidators = pendingValidators;
         finalized = true;
-        blockNumbersOfFinalizedChanges.push(block.number);
-        finalizedValidatorSets[block.number] = currentValidators;
+        epochStartHeights.push(block.number);
+        epochStartToValidatorsMapping[block.number] = currentValidators;
     }
 
     function removeValidator(address _validator) internal isFinalized returns (bool _success) {

--- a/contracts/tests/test_validator_set.py
+++ b/contracts/tests/test_validator_set.py
@@ -142,6 +142,49 @@ def test_cannot_call_finalize_change(validator_set_contract_session, accounts):
         contract.functions.finalizeChange().transact({"from": accounts[0]})
 
 
+def test_finalize_change_update_history_data_correctly(
+    validator_set_contract_session, accounts, web3
+):
+    assert (
+        validator_set_contract_session.functions.getLengthOfBlockNumbersOfFinalizedChanges().call()
+        == 0
+    )
+
+    new_validator_set = accounts[:2]
+    validator_set_contract_session.functions.testChangeValiatorSet(
+        new_validator_set
+    ).transact()
+    validator_set_contract_session.functions.testFinalizeChange().transact()
+
+    assert (
+        validator_set_contract_session.functions.getLengthOfBlockNumbersOfFinalizedChanges().call()
+        == 1
+    )
+
+    block_number_of_finalized_change = web3.eth.blockNumber
+
+    assert (
+        validator_set_contract_session.functions.blockNumbersOfFinalizedChanges(
+            0
+        ).call()
+        == block_number_of_finalized_change
+    )
+
+    finalized_validator_set_length = validator_set_contract_session.functions.getLengthOfFinalizedValidatorSet(
+        block_number_of_finalized_change
+    ).call()
+
+    assert finalized_validator_set_length == len(new_validator_set)
+
+    for i in range(0, finalized_validator_set_length):
+        assert (
+            validator_set_contract_session.functions.finalizedValidatorSets(
+                block_number_of_finalized_change, i
+            ).call()
+            == new_validator_set[i]
+        )
+
+
 def test_cannot_call_initiate_change(
     validator_set_contract_session, accounts, validators
 ):


### PR DESCRIPTION
Closes #62.

Please feel free to suggest better names for the variables. Even if they should be informative, they are quite cumbersome...
Also I'm not sure about the functions to retrieve the array lengths. We could make the assumption that non of these arrays will ever contain a zero value and let the user handle the iteration. But I guess that way it is more convenience. I haven't tested them separately. That's because I recognized it does not make much sense, since they need adjustments to the history data, which is already tested. It was just duplicated code. :man_shrugging: 
But I'm open for everything. Just a first proposal.