### PR TITLE
Feature/issue 65 change cli to parse date for locker

### DIFF
--- a/auction-deploy/auction_deploy/cli.py
+++ b/auction-deploy/auction_deploy/cli.py
@@ -361,6 +361,14 @@ def close(
     )
 
 
+def format_timestamp(timestamp: int):
+    if timestamp:
+        date_string = pendulum.from_timestamp(timestamp).to_iso8601_string()
+        return f"{timestamp} ({date_string})"
+    else:
+        return f"{timestamp}"
+
+
 @main.command(
     short_help="Prints the values of variables necessary to monitor the auction."
 )
@@ -436,8 +444,12 @@ def status(auction_address, jsonrpc):
         + str(auction_state.name)
         + ")"
     )
-    click.echo("The start time is:                      " + str(start_time))
-    click.echo("The close time is:                      " + str(close_time))
+    click.echo(
+        "The start time is:                      " + format_timestamp(start_time)
+    )
+    click.echo(
+        "The close time is:                      " + format_timestamp(close_time)
+    )
     if auction_state == auction_state.Started:
         click.echo(
             "The current price is:                   "

--- a/auction-deploy/auction_deploy/cli.py
+++ b/auction-deploy/auction_deploy/cli.py
@@ -391,6 +391,8 @@ def status(auction_address, jsonrpc):
     )
     locker_address = contracts.locker.address
     locker_initialized = contracts.locker.functions.initialized().call()
+    locker_release_timestamp = contracts.locker.functions.releaseTimestamp().call()
+
     slasher_address = ZERO_ADDRESS
     slasher_initialized = False
     if contracts.slasher is not None:
@@ -456,7 +458,11 @@ def status(auction_address, jsonrpc):
             + str(current_price_in_eth)
             + " eth"
         )
-    click.echo("The last bid price is:                   " + str(last_bid_price))
+    click.echo("The last bid price is:                  " + str(last_bid_price))
+    click.echo(
+        "Deposits will be locked until:          "
+        + format_timestamp(locker_release_timestamp)
+    )
 
 
 @main.command(short_help="Whitelists addresses for the auction")

--- a/auction-deploy/auction_deploy/cli.py
+++ b/auction-deploy/auction_deploy/cli.py
@@ -46,7 +46,7 @@ def validate_date(ctx, param, value):
         return pendulum.parse(value)
     except pendulum.parsing.exceptions.ParserError as e:
         raise click.BadParameter(
-            f'The parameter "{value}" cannot be parsed as a date'
+            f'The parameter "{value}" cannot be parsed as a date. (Try e.g. "2020-09-28", "2020-09-28T13:56")'
         ) from e
 
 
@@ -164,7 +164,7 @@ def main():
 @click.option(
     "--release-date",
     "release_date",
-    help="The release date of the deposit locker",
+    help='The release date of the deposit locker (e.g. "2020-09-28", "2020-09-28T13:56")',
     type=str,
     required=False,
     metavar="DATE",

--- a/auction-deploy/constraints.txt
+++ b/auction-deploy/constraints.txt
@@ -36,6 +36,7 @@ mypy==0.701
 mypy-extensions==0.4.1
 nodeenv==1.3.3
 parsimonious==0.8.0
+pendulum==2.0.4
 pkg-resources==0.0.0
 pluggy==0.9.0
 pre-commit==1.15.2
@@ -49,6 +50,8 @@ pycryptodome==3.8.1
 pyethash==0.1.27
 pyflakes==2.1.1
 pytest==4.4.1
+python-dateutil==2.8.0
+pytzdata==2019.1
 PyYAML==5.1
 requests==2.21.0
 rlp==1.1.0

--- a/auction-deploy/requirements.txt
+++ b/auction-deploy/requirements.txt
@@ -1,7 +1,9 @@
 click
-setuptools_scm
-git+git://github.com/trustlines-protocol/contract-deploy-tools.git
 web3
+pendulum
+git+git://github.com/trustlines-protocol/contract-deploy-tools.git
+
+setuptools_scm
 pytest
 flake8
 black

--- a/auction-deploy/setup.py
+++ b/auction-deploy/setup.py
@@ -7,7 +7,7 @@ setup(
     version="0.0.1",
     packages=find_packages(),
     package_data={"auction_deploy": ["contracts.json"]},
-    install_requires=["click"],
+    install_requires=["click", "web3", "contract-deploy-tools", "pendulum"],
     entry_points="""
     [console_scripts]
     auction-deploy=auction_deploy.cli:main

--- a/auction-deploy/tests/test_cli.py
+++ b/auction-deploy/tests/test_cli.py
@@ -132,6 +132,19 @@ def deposit_pending_auction(
     return contracts.auction
 
 
+def test_cli_release_date_option(runner):
+    deploy_result = runner.invoke(
+        main, args=f"deploy --release-date '2033-05-18 03:33:21' --jsonrpc test"
+    )
+    assert deploy_result.exception is None
+    assert deploy_result.exit_code == 0
+    auction_address = extract_auction_address(deploy_result.output)
+    contracts = get_deployed_auction_contracts(test_json_rpc, auction_address)
+    release_timestamp = contracts.locker.functions.releaseTimestamp().call()
+    # 2033-05-18 03:33:21 is timestamp 2000000001
+    assert release_timestamp == 2_000_000_001
+
+
 def test_cli_contract_parameters_set(runner):
 
     result = runner.invoke(


### PR DESCRIPTION
This allows the deposit lockers release date to be set via the --release-date option and implements #65 

It contains some additional changes to show an actual date instead of timestamps when running the status command.
