### PR TITLE
Remove the DepositPending state

### DIFF
--- a/auction-deploy/auction_deploy/cli.py
+++ b/auction-deploy/auction_deploy/cli.py
@@ -54,9 +54,8 @@ def validate_date(ctx, param, value):
 class AuctionState(Enum):
     Deployed = 0
     Started = 1
-    DepositPending = 2
-    Ended = 3
-    Failed = 4
+    Ended = 2
+    Failed = 3
 
 
 jsonrpc_option = click.option(

--- a/auction-deploy/tests/test_cli.py
+++ b/auction-deploy/tests/test_cli.py
@@ -128,7 +128,7 @@ def deposit_pending_auction(
         {"from": ether_owning_whitelist[1], "value": bid_value}
     )
 
-    ensure_auction_state(AuctionState.DepositPending)
+    ensure_auction_state(AuctionState.Ended)
     return contracts.auction
 
 


### PR DESCRIPTION
There is the weirdness that endAuction will fire the event AuctionEnded
but change to the state DepositPending. One solution to fix this is to
remove the intermediate state DepositPending. This has the advantage
that people can start withdrawing right after the auction has ended.
One might however argue that this is less safe. Let me know what you think. 

