### PR TITLE
Add AuctionDepositPending event

### DIFF
--- a/contracts/contracts/lib/Ownable.sol
+++ b/contracts/contracts/lib/Ownable.sol
@@ -11,7 +11,7 @@ pragma solidity ^0.4.11;
 contract Ownable {
     address public owner;
 
-    function Ownable() public {
+    constructor() public {
         owner = msg.sender;
     }
 

--- a/contracts/tests/test_validator_auction.py
+++ b/contracts/tests/test_validator_auction.py
@@ -480,7 +480,7 @@ def test_event_auction_failed(started_validator_auction, accounts, chain, web3):
 
 
 @pytest.mark.slow
-def test_event_auction_ended(almost_filled_validator_auction, accounts, web3):
+def test_event_deposit_pending(almost_filled_validator_auction, accounts, web3):
 
     latest_block_number = web3.eth.blockNumber
 
@@ -489,6 +489,25 @@ def test_event_auction_ended(almost_filled_validator_auction, accounts, web3):
     )
 
     close_time = web3.eth.getBlock("latest").timestamp
+
+    event = almost_filled_validator_auction.events.AuctionDepositPending.createFilter(
+        fromBlock=latest_block_number
+    ).get_all_entries()[0]["args"]
+
+    assert event["closeTime"] == close_time
+    assert event["lowestBidPrice"] == TEST_PRICE
+
+
+@pytest.mark.slow
+def test_event_auction_ended(almost_filled_validator_auction, accounts, web3):
+
+    latest_block_number = web3.eth.blockNumber
+
+    almost_filled_validator_auction.functions.bid().transact(
+        {"from": accounts[1], "value": 234}
+    )
+    close_time = web3.eth.getBlock("latest").timestamp
+    almost_filled_validator_auction.functions.depositBids().transact()
 
     event = almost_filled_validator_auction.events.AuctionEnded.createFilter(
         fromBlock=latest_block_number


### PR DESCRIPTION
Add AuctionDepositPending event which is emitted instead of AuctionEnded
to avoid the confusion that the state(DepositPending) is different from
the event (AuctionEnded)
The AuctionEnded event is emitted later when transitioning to the
AuctionEnded state with the same parameters.