### PR TITLE
adapt code to compile with solidity 0.5.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,9 +3,9 @@ version: 2.1
 executors:
   ubuntu-builder:
     docker:
-      - image: trustlines/builder:master8
+      - image: trustlines/builder:master20
         environment:
-          - SOLC_VERSION=v0.4.25
+          - SOLC_VERSION=v0.5.7
     working_directory: ~/repo
 
 # define some common commands

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,9 +3,9 @@ version: 2.1
 executors:
   ubuntu-builder:
     docker:
-      - image: trustlines/builder:master20
+      - image: trustlines/builder:master21
         environment:
-          - SOLC_VERSION=v0.5.7
+          - SOLC_VERSION=v0.5.8
     working_directory: ~/repo
 
 # define some common commands

--- a/auction-deploy/constraints.txt
+++ b/auction-deploy/constraints.txt
@@ -9,6 +9,7 @@ certifi==2019.3.9
 cffi==1.12.3
 cfgv==1.6.0
 chardet==3.0.4
+contracts-deploy-tools==0.3.0
 Click==7.0
 cryptography==2.6.1
 cytoolz==0.9.0.1

--- a/auction-deploy/requirements.txt
+++ b/auction-deploy/requirements.txt
@@ -1,8 +1,7 @@
 click
 web3
 pendulum
-git+git://github.com/trustlines-protocol/contract-deploy-tools.git
-
+contract-deploy-tools
 setuptools_scm
 pytest
 flake8

--- a/contracts/constraints.txt
+++ b/contracts/constraints.txt
@@ -10,7 +10,7 @@ cffi==1.11.5
 cfgv==1.4.0
 chardet==3.0.4
 Click==7.0
-contract-deploy-tools==0.2.1
+contract-deploy-tools==0.3.0
 cryptography==2.4.2
 cytoolz==0.9.0.1
 eth-abi==1.2.0

--- a/contracts/contracts/DepositLocker.sol
+++ b/contracts/contracts/DepositLocker.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.7;
+pragma solidity ^0.5.8;
 
 import "./lib/Ownable.sol";
 import "./DepositLockerInterface.sol";

--- a/contracts/contracts/DepositLocker.sol
+++ b/contracts/contracts/DepositLocker.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.25;
+pragma solidity ^0.5.7;
 
 import "./lib/Ownable.sol";
 import "./DepositLockerInterface.sol";

--- a/contracts/contracts/DepositLockerInterface.sol
+++ b/contracts/contracts/DepositLockerInterface.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.7;
+pragma solidity ^0.5.8;
 
 
 contract DepositLockerInterface {

--- a/contracts/contracts/DepositLockerInterface.sol
+++ b/contracts/contracts/DepositLockerInterface.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.25;
+pragma solidity ^0.5.7;
 
 
 contract DepositLockerInterface {

--- a/contracts/contracts/EquivocationInspector.sol
+++ b/contracts/contracts/EquivocationInspector.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.25;
+pragma solidity ^0.5.7;
 
 import "./lib/RLPReader.sol";
 import "./lib/ECDSA.sol";
@@ -24,8 +24,8 @@ library EquivocationInspector {
      * @param _signature  the signature the address should be recovered from
      */
     function getSignerAddress(
-        bytes _data,
-        bytes _signature
+        bytes memory _data,
+        bytes memory _signature
     )
         internal
         pure

--- a/contracts/contracts/EquivocationInspector.sol
+++ b/contracts/contracts/EquivocationInspector.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.7;
+pragma solidity ^0.5.8;
 
 import "./lib/RLPReader.sol";
 import "./lib/ECDSA.sol";

--- a/contracts/contracts/TestEquivocationInspector.sol
+++ b/contracts/contracts/TestEquivocationInspector.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.25;
+pragma solidity ^0.5.7;
 
 /*
   The sole purpose of this file is to be able to test the internal functions of the EquivocationInspector.
@@ -13,8 +13,8 @@ contract TestEquivocationInspector {
     function() external {}
 
     function testGetSignerAddress(
-        bytes _data,
-        bytes _signature
+        bytes memory _data,
+        bytes memory _signature
     )
         public
         pure

--- a/contracts/contracts/TestEquivocationInspector.sol
+++ b/contracts/contracts/TestEquivocationInspector.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.7;
+pragma solidity ^0.5.8;
 
 /*
   The sole purpose of this file is to be able to test the internal functions of the EquivocationInspector.

--- a/contracts/contracts/TestValidatorAuctionFixedPrice.sol
+++ b/contracts/contracts/TestValidatorAuctionFixedPrice.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.7;
+pragma solidity ^0.5.8;
 
 /*
   The sole purpose of this contract is to be able to test the auction without having to bother with price

--- a/contracts/contracts/TestValidatorAuctionFixedPrice.sol
+++ b/contracts/contracts/TestValidatorAuctionFixedPrice.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.25;
+pragma solidity ^0.5.7;
 
 /*
   The sole purpose of this contract is to be able to test the auction without having to bother with price
@@ -9,7 +9,7 @@ import "./ValidatorAuction.sol";
 
 
 contract TestValidatorAuctionFixedPrice is ValidatorAuction {
-    constructor(DepositLocker _depositLocker) ValidatorAuction(100, 14, 50, 123, _depositLocker) {
+    constructor(DepositLocker _depositLocker) public ValidatorAuction(100, 14, 50, 123, _depositLocker) {
     }
 
     function currentPrice() public view returns (uint) {

--- a/contracts/contracts/TestValidatorSet.sol
+++ b/contracts/contracts/TestValidatorSet.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.7;
+pragma solidity ^0.5.8;
 
 /*
   The sole purpose of this file is to be able to test the internal functions of the ValidatorSet

--- a/contracts/contracts/TestValidatorSet.sol
+++ b/contracts/contracts/TestValidatorSet.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.25;
+pragma solidity ^0.5.7;
 
 /*
   The sole purpose of this file is to be able to test the internal functions of the ValidatorSet
@@ -21,7 +21,7 @@ contract TestValidatorSet is ValidatorSet {
      *      without the need to report a validator, which is the only opportunity to
      *      change the set in the origin contract.
      */
-    function testChangeValiatorSet(address[] _newValidatorSet) public {
+    function testChangeValiatorSet(address[] memory _newValidatorSet) public {
         require(finalized, "Validator set change is already ongoing!");
         pendingValidators = _newValidatorSet;
         initiateChange(_newValidatorSet);

--- a/contracts/contracts/ValidatorAuction.sol
+++ b/contracts/contracts/ValidatorAuction.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.25;
+pragma solidity ^0.5.7;
 
 import "./lib/Ownable.sol";
 import "./DepositLocker.sol";
@@ -125,7 +125,7 @@ contract ValidatorAuction is Ownable {
         }
     }
 
-    function addToWhitelist(address[] addressesToWhitelist) public onlyOwner stateIs(AuctionState.Deployed) {
+    function addToWhitelist(address[] memory addressesToWhitelist) public onlyOwner stateIs(AuctionState.Deployed) {
         for (uint32 i = 0; i < addressesToWhitelist.length; i++) {
             whitelist[addressesToWhitelist[i]] = true;
             emit AddressWhitelisted(addressesToWhitelist[i]);

--- a/contracts/contracts/ValidatorAuction.sol
+++ b/contracts/contracts/ValidatorAuction.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.7;
+pragma solidity ^0.5.8;
 
 import "./lib/Ownable.sol";
 import "./DepositLocker.sol";

--- a/contracts/contracts/ValidatorSet.sol
+++ b/contracts/contracts/ValidatorSet.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.25;
+pragma solidity ^0.5.7;
 
 import "./EquivocationInspector.sol";
 
@@ -50,7 +50,7 @@ contract ValidatorSet {
 
     function() external {}
 
-    function init(address[] _validators) external returns (bool _success) {
+    function init(address[] calldata _validators) external returns (bool _success) {
         require(
             !initiated,
             "Can not initate twice."
@@ -69,11 +69,11 @@ contract ValidatorSet {
         return true;
     }
 
-    function getEpochStartHeights() external view returns(uint[]) {
+    function getEpochStartHeights() external view returns(uint[] memory) {
         return epochStartHeights;
     }
 
-    function getValidators(uint _epochStart) external view returns(address[]) {
+    function getValidators(uint _epochStart) external view returns(address[] memory) {
         return epochValidators[_epochStart];
     }
 
@@ -92,10 +92,10 @@ contract ValidatorSet {
      * @param _signatureTwo           the signature related to the second block
      */
     function reportMaliciousValidator(
-        bytes _rlpUnsignedHeaderOne,
-        bytes _signatureOne,
-        bytes _rlpUnsignedHeaderTwo,
-        bytes _signatureTwo
+        bytes calldata _rlpUnsignedHeaderOne,
+        bytes calldata _signatureOne,
+        bytes calldata _rlpUnsignedHeaderTwo,
+        bytes calldata _signatureTwo
     )
         external
     {
@@ -124,7 +124,7 @@ contract ValidatorSet {
 
     // Get current validator set (last enacted or initial if no changes ever made)
     // do not modify this function, aura will likely bug
-    function getValidators() public view returns (address[] _validators) {
+    function getValidators() public view returns (address[] memory _validators) {
         _validators = currentValidators;
     }
 
@@ -158,9 +158,9 @@ contract ValidatorSet {
         return true;
     }
 
-    function initiateChange(address[] _newValidatorSet) internal {
+    function initiateChange(address[] memory _newValidatorSet) internal {
         finalized = false;
-        emit InitiateChange(block.blockhash(block.number-1), _newValidatorSet);
+        emit InitiateChange(blockhash(block.number-1), _newValidatorSet);
     }
 
 }

--- a/contracts/contracts/ValidatorSet.sol
+++ b/contracts/contracts/ValidatorSet.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.7;
+pragma solidity ^0.5.8;
 
 import "./EquivocationInspector.sol";
 

--- a/contracts/contracts/ValidatorSlasher.sol
+++ b/contracts/contracts/ValidatorSlasher.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.7;
+pragma solidity ^0.5.8;
 
 import "./lib/Ownable.sol";
 import "./DepositLockerInterface.sol";

--- a/contracts/contracts/ValidatorSlasher.sol
+++ b/contracts/contracts/ValidatorSlasher.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.25;
+pragma solidity ^0.5.7;
 
 import "./lib/Ownable.sol";
 import "./DepositLockerInterface.sol";
@@ -37,10 +37,10 @@ contract ValidatorSlasher is Ownable {
      * @param _signatureTwo           the signature related to the second block
      */
     function reportMaliciousValidator(
-        bytes _rlpUnsignedHeaderOne,
-        bytes _signatureOne,
-        bytes _rlpUnsignedHeaderTwo,
-        bytes _signatureTwo
+        bytes calldata _rlpUnsignedHeaderOne,
+        bytes calldata _signatureOne,
+        bytes calldata _rlpUnsignedHeaderTwo,
+        bytes calldata _signatureTwo
     )
         external
     {

--- a/contracts/contracts/lib/ECDSA.sol
+++ b/contracts/contracts/lib/ECDSA.sol
@@ -23,7 +23,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-pragma solidity ^0.5.7;
+pragma solidity ^0.5.8;
 
 /**
  * @title Elliptic curve signature operations

--- a/contracts/contracts/lib/ECDSA.sol
+++ b/contracts/contracts/lib/ECDSA.sol
@@ -23,7 +23,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.7;
 
 /**
  * @title Elliptic curve signature operations
@@ -38,7 +38,7 @@ library ECDSA {
      * @param hash bytes32 message, the hash is the signed message. What is recovered is the signer address.
      * @param signature bytes signature, the signature is generated using web3.eth.sign()
      */
-    function recover(bytes32 hash, bytes signature) internal pure returns (address) {
+    function recover(bytes32 hash, bytes memory signature) internal pure returns (address) {
         bytes32 r;
         bytes32 s;
         uint8 v;

--- a/contracts/contracts/lib/Ownable.sol
+++ b/contracts/contracts/lib/Ownable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.7;
+pragma solidity ^0.5.8;
 
 /*
  * Ownable

--- a/contracts/contracts/lib/Ownable.sol
+++ b/contracts/contracts/lib/Ownable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.11;
+pragma solidity ^0.5.7;
 
 /*
  * Ownable

--- a/contracts/contracts/lib/RLPReader.sol
+++ b/contracts/contracts/lib/RLPReader.sol
@@ -27,7 +27,7 @@
  * The source has not been touched within this project.
  */
 
-pragma solidity ^0.5.7;
+pragma solidity ^0.5.8;
 
 library RLPReader {
     uint8 constant STRING_SHORT_START = 0x80;

--- a/contracts/contracts/lib/RLPReader.sol
+++ b/contracts/contracts/lib/RLPReader.sol
@@ -27,7 +27,7 @@
  * The source has not been touched within this project.
  */
 
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.7;
 
 library RLPReader {
     uint8 constant STRING_SHORT_START = 0x80;
@@ -164,7 +164,7 @@ library RLPReader {
     /** RLPItem conversions into data types **/
 
     // @returns raw rlp encoding in bytes
-    function toRlpBytes(RLPItem memory item) internal pure returns (bytes) {
+    function toRlpBytes(RLPItem memory item) internal pure returns (bytes memory) {
         bytes memory result = new bytes(item.len);
         
         uint ptr;
@@ -207,7 +207,7 @@ library RLPReader {
         return result;
     }
 
-    function toBytes(RLPItem memory item) internal pure returns (bytes) {
+    function toBytes(RLPItem memory item) internal pure returns (bytes memory) {
         uint offset = _payloadOffset(item.memPtr);
         uint len = item.len - offset; // data length
         bytes memory result = new bytes(len);

--- a/contracts/contracts/lib/it_set_lib.sol
+++ b/contracts/contracts/lib/it_set_lib.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.7;
+pragma solidity ^0.5.8;
 
 
 /**

--- a/contracts/contracts/lib/it_set_lib.sol
+++ b/contracts/contracts/lib/it_set_lib.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.11;
+pragma solidity ^0.5.7;
 
 
 /**

--- a/contracts/requirements.txt
+++ b/contracts/requirements.txt
@@ -4,7 +4,7 @@ flake8
 pep8-naming
 rlp
 eth-utils
-contract-deploy-tools>=0.2.0
+contract-deploy-tools>=0.3.0
 black
 pre-commit
 attrs


### PR DESCRIPTION
The code changes needed are mostly explicitly setting the data location. I've
followed what the solidity compiler was already suggesting. Breaking changes in
to 0.5.x series are documented in [1].

The problem is, that a lot of tests are failing now, some of them with something
like 'eth.exceptions.InvalidInstruction: Invalid opcode 0x1c @ 18'. My guess
here is that the new default target option is to blame. It changed from
byzantium in 0.5.4 [2] to petersberg in 0.5.7 [3]. My guess is that the default
in 0.4.25 is byzantium.

See https://github.com/trustlines-protocol/blockchain/issues/83

[1] https://solidity.readthedocs.io/en/latest/050-breaking-changes.html
[2] https://solidity.readthedocs.io/en/v0.5.4/using-the-compiler.html#target-options
[3] https://solidity.readthedocs.io/en/v0.5.7/using-the-compiler.html#target-options