### PR TITLE
Upgrade parity version tag in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,7 +24,7 @@ RUN mkdir -p $PARITY_HOME_DIR && \
 
 ## Get the build binaries from the previous image.
 ## (using environment variable from previous image not possible...)
-COPY --from=parity/parity:v2.1.11 /bin/parity $PARITY_BIN
+COPY --from=parity/parity:v2.4.6 /bin/parity $PARITY_BIN
 
 ## Configuring
 ### Network RPC WebSocket SecretStore IPFS


### PR DESCRIPTION
Closes #99

I switched to a version which @saschagoebel has mentioned to work well. The image can now build again and works fine when connecting to our test network. More checks to the image itself will come up for the planned fork.
I have no idea when Parity removes version tags on _DockerHub_. Possibly we have to do updates continuously. 