### PR TITLE
Feature/erc20 token

### DIFF
--- a/contracts/contracts/SafeMath.sol
+++ b/contracts/contracts/SafeMath.sol
@@ -1,0 +1,124 @@
+pragma solidity ^0.5.8;
+
+/**
+ * @dev Wrappers over Solidity's arithmetic operations with added overflow
+ * checks.
+ *
+ * Arithmetic operations in Solidity wrap on overflow. This can easily result
+ * in bugs, because programmers usually assume that an overflow raises an
+ * error, which is the standard behavior in high level programming languages.
+ * `SafeMath` restores this intuition by reverting the transaction when an
+ * operation overflows.
+ *
+ * Using this library instead of the unchecked operations eliminates an entire
+ * class of bugs, so it's recommended to use it always.
+ */
+library SafeMath {
+    /**
+     * @dev Returns the addition of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `+` operator.
+     *
+     * Requirements:
+     * - Addition cannot overflow.
+     */
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a, "SafeMath: addition overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        require(b <= a, "SafeMath: subtraction overflow");
+        uint256 c = a - b;
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the multiplication of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `*` operator.
+     *
+     * Requirements:
+     * - Multiplication cannot overflow.
+     */
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+        // benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-solidity/pull/522
+        if (a == 0) {
+            return 0;
+        }
+
+        uint256 c = a * b;
+        require(c / a == b, "SafeMath: multiplication overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        // Solidity only automatically asserts when dividing by 0
+        require(b > 0, "SafeMath: division by zero");
+        uint256 c = a / b;
+        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        require(b != 0, "SafeMath: modulo by zero");
+        return a % b;
+    }
+}
+
+/*
+The MIT License (MIT)
+
+Copyright (c) 2016-2019 zOS Global Limited
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+*/

--- a/contracts/contracts/TrustlinesNetworkToken.sol
+++ b/contracts/contracts/TrustlinesNetworkToken.sol
@@ -4,8 +4,10 @@ import "./SafeMath.sol";
 
 
 contract TrustlinesNetworkToken {
+
     using SafeMath for uint256;
 
+    uint constant MAX_UINT = 2**256 - 1;
     string private _name;
     string private _symbol;
     uint8 private _decimals;
@@ -56,7 +58,12 @@ contract TrustlinesNetworkToken {
 
     function transferFrom(address sender, address recipient, uint256 amount) public returns (bool) {
         _transfer(sender, recipient, amount);
-        _approve(sender, msg.sender, _allowances[sender][msg.sender].sub(amount));
+
+        allowance = _allowances[sender][msg.sender];
+        updated_allowance = allowance.sub(amount);
+        if (allowance < MAX_UINT) {
+            _approve(sender, msg.sender,updated_allowance);
+        }
     }
 
     function increaseAllowance(address spender, uint256 addedValue) public returns (bool) {

--- a/contracts/contracts/TrustlinesNetworkToken.sol
+++ b/contracts/contracts/TrustlinesNetworkToken.sol
@@ -1,0 +1,132 @@
+pragma solidity ^0.5.8;
+
+import "./SafeMath.sol";
+
+
+contract TrustlinesNetworkToken {
+    using SafeMath for uint256;
+
+    string private _name;
+    string private _symbol;
+    uint8 private _decimals;
+    uint256 private _totalSupply;
+
+    mapping (address => uint256) private _balances;
+    mapping (address => mapping (address => uint256)) private _allowances;
+
+    constructor (string memory name, string memory symbol, uint8 decimals, address preMintAddress, uint256 preMintAmount) public {
+        _name = name;
+        _symbol = symbol;
+        _decimals = decimals;
+
+        _mint(preMintAddress, preMintAmount);
+    }
+
+    function balanceOf(address account) public view returns (uint256) {
+        return _balances[account];
+    }
+
+    function allowance(address owner, address spender) public view returns (uint256) {
+        return _allowances[owner][spender];
+    }
+
+    function name() public view returns (string memory) {
+        return _name;
+    }
+
+    function symbol() public view returns (string memory) {
+        return _symbol;
+    }
+
+    function decimals() public view returns (uint8) {
+        return _decimals;
+    }
+
+    function totalSupply() public view returns (uint256) {
+        return _totalSupply;
+    }
+
+    function transfer(address recipient, uint256 amount) public returns (bool) {
+        _transfer(msg.sender, recipient, amount);
+    }
+
+    function approve(address spender, uint256 value) public returns (bool) {
+        _approve(msg.sender, spender, value);
+    }
+
+    function transferFrom(address sender, address recipient, uint256 amount) public returns (bool) {
+        _transfer(sender, recipient, amount);
+        _approve(sender, msg.sender, _allowances[sender][msg.sender].sub(amount));
+    }
+
+    function increaseAllowance(address spender, uint256 addedValue) public returns (bool) {
+        _approve(msg.sender, spender, _allowances[msg.sender][spender].add(addedValue));
+    }
+
+    function decreaseAllowance(address spender, uint256 subtractedValue) public returns (bool) {
+        _approve(msg.sender, spender, _allowances[msg.sender][spender].sub(subtractedValue));
+    }
+
+    function burn(uint256 amount) public {
+        _burn(msg.sender, amount);
+    }
+
+    function burnFrom(address account, uint256 amount) public {
+        _burnFrom(account, amount);
+    }
+
+    function _mint(address account, uint256 amount) internal {
+        require(account != address(0), "ERC20: mint to the zero address");
+
+        _totalSupply = _totalSupply.add(amount);
+        _balances[account] = _balances[account].add(amount);
+        emit Transfer(address(0), account, amount);
+    }
+
+    function _transfer(address sender, address recipient, uint256 amount) internal {
+        require(sender != address(0), "ERC20: transfer from the zero address");
+        require(recipient != address(0), "ERC20: transfer to the zero address");
+
+        _balances[sender] = _balances[sender].sub(amount);
+        _balances[recipient] = _balances[recipient].add(amount);
+        emit Transfer(sender, recipient, amount);
+    }
+
+    function _approve(address owner, address spender, uint256 value) internal {
+        require(owner != address(0), "ERC20: approve from the zero address");
+        require(spender != address(0), "ERC20: approve to the zero address");
+
+        _allowances[owner][spender] = value;
+        emit Approval(owner, spender, value);
+    }
+
+    function _burn(address account, uint256 value) internal {
+        require(account != address(0), "ERC20: burn from the zero address");
+
+        _totalSupply = _totalSupply.sub(value);
+        _balances[account] = _balances[account].sub(value);
+        emit Transfer(account, address(0), value);
+    }
+
+    function _burnFrom(address account, uint256 amount) internal {
+        _burn(account, amount);
+        _approve(account, msg.sender, _allowances[account][msg.sender].sub(amount));
+    }
+}
+
+/*
+The MIT License (MIT)
+
+Copyright (c) 2016-2019 zOS Global Limited
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+*/

--- a/contracts/contracts/TrustlinesNetworkToken.sol
+++ b/contracts/contracts/TrustlinesNetworkToken.sol
@@ -95,6 +95,7 @@ contract TrustlinesNetworkToken {
     function _approve(address owner, address spender, uint256 value) internal {
         require(owner != address(0), "ERC20: approve from the zero address");
         require(spender != address(0), "ERC20: approve to the zero address");
+        require(value == 0 || allowed[owner][spender] == 0, "ERC20: approve only to or from 0 value");
 
         _allowances[owner][spender] = value;
         emit Approval(owner, spender, value);

--- a/contracts/contracts/TrustlinesNetworkToken.sol
+++ b/contracts/contracts/TrustlinesNetworkToken.sol
@@ -16,6 +16,9 @@ contract TrustlinesNetworkToken {
     mapping (address => uint256) private _balances;
     mapping (address => mapping (address => uint256)) private _allowances;
 
+    event Transfer(address indexed from, address indexed to, uint256 value);
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+
     constructor (string memory name, string memory symbol, uint8 decimals, address preMintAddress, uint256 preMintAmount) public {
         _name = name;
         _symbol = symbol;
@@ -53,33 +56,22 @@ contract TrustlinesNetworkToken {
     }
 
     function approve(address spender, uint256 value) public returns (bool) {
+        require(value == 0 || _allowances[msg.sender][spender] == 0, "ERC20: approve only to or from 0 value");
         _approve(msg.sender, spender, value);
     }
 
     function transferFrom(address sender, address recipient, uint256 amount) public returns (bool) {
         _transfer(sender, recipient, amount);
 
-        allowance = _allowances[sender][msg.sender];
-        updated_allowance = allowance.sub(amount);
+        uint allowance = _allowances[sender][msg.sender];
+        uint updatedAllowance = allowance.sub(amount);
         if (allowance < MAX_UINT) {
-            _approve(sender, msg.sender,updated_allowance);
+            _approve(sender, msg.sender, updatedAllowance);
         }
-    }
-
-    function increaseAllowance(address spender, uint256 addedValue) public returns (bool) {
-        _approve(msg.sender, spender, _allowances[msg.sender][spender].add(addedValue));
-    }
-
-    function decreaseAllowance(address spender, uint256 subtractedValue) public returns (bool) {
-        _approve(msg.sender, spender, _allowances[msg.sender][spender].sub(subtractedValue));
     }
 
     function burn(uint256 amount) public {
         _burn(msg.sender, amount);
-    }
-
-    function burnFrom(address account, uint256 amount) public {
-        _burnFrom(account, amount);
     }
 
     function _mint(address account, uint256 amount) internal {
@@ -102,7 +94,6 @@ contract TrustlinesNetworkToken {
     function _approve(address owner, address spender, uint256 value) internal {
         require(owner != address(0), "ERC20: approve from the zero address");
         require(spender != address(0), "ERC20: approve to the zero address");
-        require(value == 0 || allowed[owner][spender] == 0, "ERC20: approve only to or from 0 value");
 
         _allowances[owner][spender] = value;
         emit Approval(owner, spender, value);
@@ -114,11 +105,6 @@ contract TrustlinesNetworkToken {
         _totalSupply = _totalSupply.sub(value);
         _balances[account] = _balances[account].sub(value);
         emit Transfer(account, address(0), value);
-    }
-
-    function _burnFrom(address account, uint256 amount) internal {
-        _burn(account, amount);
-        _approve(account, msg.sender, _allowances[account][msg.sender].sub(amount));
     }
 }
 

--- a/contracts/tests/conftest.py
+++ b/contracts/tests/conftest.py
@@ -319,3 +319,29 @@ def block_reward_amount(chain, web3):
     chain.mine_block()
     balance_after = web3.eth.getBalance(mining_reward_address)
     return balance_after - balance_before
+
+
+@pytest.fixture(scope="session")
+def tln_token_contract(deploy_contract, premint_token_address, premint_token_value):
+    token_name = "Trustlines Network Token"
+    token_symbol = "TLN"
+    token_decimal = 18
+    constructor_args = (
+        token_name,
+        token_symbol,
+        token_decimal,
+        premint_token_address,
+        premint_token_value,
+    )
+
+    return deploy_contract("TrustlinesNetworkToken", constructor_args=constructor_args)
+
+
+@pytest.fixture(scope="session")
+def premint_token_address(accounts):
+    return accounts[0]
+
+
+@pytest.fixture(scope="session")
+def premint_token_value():
+    return 132456

--- a/contracts/tests/test_token.py
+++ b/contracts/tests/test_token.py
@@ -1,0 +1,164 @@
+import pytest
+import eth_tester.exceptions
+
+
+@pytest.fixture()
+def tln_token_contract_with_allowance(
+    tln_token_contract, allowed_spender, allowance, premint_token_address
+):
+
+    tln_token_contract.functions.approve(allowed_spender, allowance).transact(
+        {"from": premint_token_address}
+    )
+    assert (
+        tln_token_contract.functions.allowance(
+            premint_token_address, allowed_spender
+        ).call()
+        == allowance
+    )
+
+    return tln_token_contract
+
+
+@pytest.fixture(scope="session")
+def allowed_spender(accounts):
+    return accounts[1]
+
+
+@pytest.fixture(scope="session")
+def allowance():
+    return 12345
+
+
+def test_premint(tln_token_contract, premint_token_address, premint_token_value):
+    assert tln_token_contract.functions.totalSupply().call() == premint_token_value
+    assert (
+        tln_token_contract.functions.balanceOf(premint_token_address).call()
+        == premint_token_value
+    )
+
+
+def test_race_condition_fix_on_allowance(
+    tln_token_contract_with_allowance,
+    chain,
+    accounts,
+    premint_token_address,
+    allowed_spender,
+    allowance,
+):
+    allower = premint_token_address
+    spender = allowed_spender
+    receiver = accounts[3]
+
+    chain.disable_auto_mine_transactions()
+
+    with pytest.raises(eth_tester.exceptions.TransactionFailed):
+        tln_token_contract_with_allowance.functions.transferFrom(
+            allower, receiver, allowance
+        ).transact({"from": spender})
+        tln_token_contract_with_allowance.functions.approve(
+            spender, allowance
+        ).transact({"from": allower})
+    chain.enable_auto_mine_transactions()
+
+
+def test_unlimited_allowance(tln_token_contract, premint_token_address, accounts):
+    max_uint = 2 ** 256 - 1
+    spender = accounts[1]
+    receiver = accounts[2]
+    spending = 456
+
+    tln_token_contract.functions.approve(spender, max_uint).transact(
+        {"from": premint_token_address}
+    )
+    tln_token_contract.functions.transferFrom(
+        premint_token_address, receiver, spending
+    ).transact({"from": spender})
+
+    assert (
+        tln_token_contract.functions.allowance(premint_token_address, spender).call()
+        == max_uint
+    )
+
+
+def test_burning(tln_token_contract, premint_token_address, premint_token_value):
+    burn_amount = 654
+    tln_token_contract.functions.burn(burn_amount).transact(
+        {"from": premint_token_address}
+    )
+
+    assert (
+        tln_token_contract.functions.balanceOf(premint_token_address).call()
+        == premint_token_value - burn_amount
+    )
+    assert (
+        tln_token_contract.functions.totalSupply().call()
+        == premint_token_value - burn_amount
+    )
+
+
+def test_transfer(
+    tln_token_contract, premint_token_address, premint_token_value, accounts
+):
+    transfer_amount = 789
+    receiver = accounts[2]
+    tln_token_contract.functions.transfer(receiver, transfer_amount).transact(
+        {"from": premint_token_address}
+    )
+
+    assert (
+        tln_token_contract.functions.balanceOf(premint_token_address).call()
+        == premint_token_value - transfer_amount
+    )
+    assert tln_token_contract.functions.balanceOf(receiver).call() == transfer_amount
+
+
+def test_approve(tln_token_contract, accounts):
+    approver = accounts[2]
+    receiver = accounts[3]
+    allowance = 852
+
+    tln_token_contract.functions.approve(receiver, allowance).transact(
+        {"from": approver}
+    )
+
+    assert (
+        tln_token_contract.functions.allowance(approver, receiver).call() == allowance
+    )
+
+
+def test_transfer_from(
+    tln_token_contract_with_allowance,
+    premint_token_address,
+    premint_token_value,
+    allowed_spender,
+    allowance,
+    accounts,
+):
+    receiver = accounts[5]
+    transfer_amount = 456
+
+    tln_token_contract_with_allowance.functions.transferFrom(
+        premint_token_address, receiver, transfer_amount
+    ).transact({"from": allowed_spender})
+
+    assert (
+        tln_token_contract_with_allowance.functions.balanceOf(
+            premint_token_address
+        ).call()
+        == premint_token_value - transfer_amount
+    )
+    assert (
+        tln_token_contract_with_allowance.functions.balanceOf(receiver).call()
+        == transfer_amount
+    )
+    assert (
+        tln_token_contract_with_allowance.functions.balanceOf(allowed_spender).call()
+        == 0
+    )
+    assert (
+        tln_token_contract_with_allowance.functions.allowance(
+            premint_token_address, allowed_spender
+        ).call()
+        == allowance - transfer_amount
+    )


### PR DESCRIPTION
close https://github.com/trustlines-network/project/issues/354
Functions rely on checks by safeMath.lib, we could make requires more obvious and remove safeMath.lib
Otherwise I'd wish to refactor safeMath.lib in contract-library to use a more recent version with a tracked source.