### PR TITLE
Feature/bridge validators

### DIFF
--- a/contracts/contracts/BridgeValidators.sol
+++ b/contracts/contracts/BridgeValidators.sol
@@ -7,22 +7,22 @@ import "./ValidatorProxy.sol";
 contract BridgeValidators is IBridgeValidators {
 
     ValidatorProxy public validatorProxy;
-    uint public requiredSignatureDivisor;
-    uint public requiredSignatureMultiplier;
+    uint public requiredSignaturesDivisor;
+    uint public requiredSignaturesMultiplier;
 
-    constructor(ValidatorProxy _validatorProxy, uint _requiredSignatureDivisor, uint _requiredSignatureMultiplier) public {
+    constructor(ValidatorProxy _validatorProxy, uint _requiredSignaturesDivisor, uint _requiredSignaturesMultiplier) public {
         validatorProxy = _validatorProxy;
-        requiredSignatureDivisor = _requiredSignatureDivisor;
-        requiredSignatureMultiplier = _requiredSignatureMultiplier;
+        requiredSignaturesDivisor = _requiredSignaturesDivisor;
+        requiredSignaturesMultiplier = _requiredSignaturesMultiplier;
     }
 
     function isValidator(address _validator) public view returns(bool) {
         return validatorProxy.isValidator(_validator);
     }
 
-    function requiredSignatures() public view returns(uint256) {
-        numberOfValidators = validatorProxy.numberOfValidators();
-        return numberOfValidators * _requiredSignatureMultiplier / _requiredSignatureDivisor;
+    function requiredSignatures() public returns(uint256) {
+        uint numberOfValidators = validatorProxy.numberOfValidators();
+        return numberOfValidators * requiredSignaturesMultiplier / requiredSignaturesDivisor;
     }
 
     function owner() public view returns(address) {

--- a/contracts/contracts/BridgeValidators.sol
+++ b/contracts/contracts/BridgeValidators.sol
@@ -1,0 +1,31 @@
+pragma solidity ^0.5.8;
+
+import "./lib/IBridgeValidators.sol";
+import "./ValidatorProxy.sol";
+
+
+contract BridgeValidators is IBridgeValidators {
+
+    ValidatorProxy public validatorProxy;
+    uint public requiredSignatureDivisor;
+    uint public requiredSignatureMultiplier;
+
+    constructor(ValidatorProxy _validatorProxy, uint _requiredSignatureDivisor, uint _requiredSignatureMultiplier) public {
+        validatorProxy = _validatorProxy;
+        requiredSignatureDivisor = _requiredSignatureDivisor;
+        requiredSignatureMultiplier = _requiredSignatureMultiplier;
+    }
+
+    function isValidator(address _validator) public view returns(bool) {
+        return validatorProxy.isValidator(_validator);
+    }
+
+    function requiredSignatures() public view returns(uint256) {
+        numberOfValidators = validatorProxy.numberOfValidators();
+        return numberOfValidators * _requiredSignatureMultiplier / _requiredSignatureDivisor;
+    }
+
+    function owner() public view returns(address) {
+        return address(0);
+    }
+}

--- a/contracts/contracts/TestValidatorProxy.sol
+++ b/contracts/contracts/TestValidatorProxy.sol
@@ -1,0 +1,11 @@
+pragma solidity ^0.5.8;
+
+import "./ValidatorProxy.sol";
+
+
+contract TestValidatorProxy is ValidatorProxy {
+
+    constructor (address _systemAddress) public {
+        systemAddress = _systemAddress;
+    }
+}

--- a/contracts/contracts/ValidatorProxy.sol
+++ b/contracts/contracts/ValidatorProxy.sol
@@ -1,6 +1,12 @@
 pragma solidity ^0.5.8;
 
 
+/**
+    This contract gives access to an up to date validator set on chain, that can be used by any other contracts.
+    Its validator set is to be updated by validators contracts when the system address calls finalizeChange().
+    This way, the `validators` array in this contract should remain correct throughout forks.
+*/
+
 contract ValidatorProxy {
 
     mapping (address => bool) public isValidator;

--- a/contracts/contracts/ValidatorProxy.sol
+++ b/contracts/contracts/ValidatorProxy.sol
@@ -1,0 +1,31 @@
+pragma solidity ^0.5.8;
+
+
+contract ValidatorProxy {
+
+    mapping (address => bool) public isValidator;
+    address public systemAddress = 0xffffFFFfFFffffffffffffffFfFFFfffFFFfFFfE;
+    address[] public validators;
+
+    function updateValidators(address[] memory newValidators) public {
+        require(tx.origin == systemAddress, "Only the system address can be responsible for the call of this function.");  // solium-disable-line security/no-tx-origin
+
+        for (uint i = 0; i < validators.length; i++) {
+            isValidator[validators[i]] = false;
+        }
+
+        for (uint i = 0; i < newValidators.length; i++) {
+            isValidator[newValidators[i]] = true;
+        }
+
+        validators = newValidators;
+    }
+
+    function numberOfValidators() public returns(uint) {
+        return validators.length;
+    }
+
+    function getValidators() public returns(address[] memory) {
+        return validators;
+    }
+}

--- a/contracts/contracts/lib/IBridgeValidators.sol
+++ b/contracts/contracts/lib/IBridgeValidators.sol
@@ -1,0 +1,8 @@
+pragma solidity 0.5.8;
+
+
+interface IBridgeValidators {
+    function isValidator(address _validator) external view returns(bool);
+    function requiredSignatures() external returns(uint256);  // removed `view` from original poa bridge interface
+    function owner() external view returns(address);
+}

--- a/contracts/tests/conftest.py
+++ b/contracts/tests/conftest.py
@@ -358,6 +358,51 @@ def validator_proxy_contract(deploy_contract, web3, validator_proxy_owner):
     return contract
 
 
+@pytest.fixture()
+def validator_proxy_with_validators(
+    validator_proxy_contract, validator_proxy_owner, proxy_validators
+):
+    validator_proxy_contract.functions.updateValidators(proxy_validators).transact(
+        {"from": validator_proxy_owner}
+    )
+    return validator_proxy_contract
+
+
+@pytest.fixture(scope="session")
+def proxy_validators(accounts):
+    return accounts[:5]
+
+
 @pytest.fixture(scope="session")
 def validator_proxy_owner(accounts):
     return accounts[0]
+
+
+@pytest.fixture(scope="session")
+def bridge_validators_contract(
+    deploy_contract,
+    web3,
+    validator_proxy_contract,
+    bridge_required_signatures_divisor,
+    bridge_required_signatures_multiplier,
+):
+    contract = deploy_contract(
+        "BridgeValidators",
+        constructor_args=(
+            validator_proxy_contract.address,
+            bridge_required_signatures_divisor,
+            bridge_required_signatures_multiplier,
+        ),
+    )
+
+    return contract
+
+
+@pytest.fixture(scope="session")
+def bridge_required_signatures_divisor():
+    return 2
+
+
+@pytest.fixture(scope="session")
+def bridge_required_signatures_multiplier():
+    return 1

--- a/contracts/tests/conftest.py
+++ b/contracts/tests/conftest.py
@@ -345,3 +345,19 @@ def premint_token_address(accounts):
 @pytest.fixture(scope="session")
 def premint_token_value():
     return 132456
+
+
+@pytest.fixture(scope="session")
+def validator_proxy_contract(deploy_contract, web3, validator_proxy_owner):
+    contract = deploy_contract(
+        "TestValidatorProxy", constructor_args=(validator_proxy_owner,)
+    )
+
+    assert contract.functions.systemAddress().call() == validator_proxy_owner
+
+    return contract
+
+
+@pytest.fixture(scope="session")
+def validator_proxy_owner(accounts):
+    return accounts[0]

--- a/contracts/tests/test_bridge_validators.py
+++ b/contracts/tests/test_bridge_validators.py
@@ -1,0 +1,32 @@
+f"black is stupid"
+
+
+def test_is_validator(
+    bridge_validators_contract, validator_proxy_with_validators, proxy_validators
+):
+    for validator in proxy_validators:
+        assert bridge_validators_contract.functions.isValidator(validator).call()
+
+
+def test_required_signature(
+    accounts,
+    bridge_validators_contract,
+    validator_proxy_with_validators,
+    proxy_validators,
+    bridge_required_signatures_divisor,
+    bridge_required_signatures_multiplier,
+):
+    required_signature = (
+        bridge_validators_contract.functions.requiredSignatures().call()
+    )
+    assert (
+        required_signature
+        == len(proxy_validators)
+        * bridge_required_signatures_multiplier
+        // bridge_required_signatures_divisor
+    )
+
+
+def test_owner(bridge_validators_contract):
+    zero_address = "0x0000000000000000000000000000000000000000"
+    assert bridge_validators_contract.functions.owner().call() == zero_address

--- a/contracts/tests/test_validator_proxy.py
+++ b/contracts/tests/test_validator_proxy.py
@@ -1,0 +1,64 @@
+import pytest
+import eth_tester.exceptions
+
+
+@pytest.fixture()
+def validator_proxy_with_validators(
+    validator_proxy_contract, validator_proxy_owner, proxy_validators
+):
+    validator_proxy_contract.functions.updateValidators(proxy_validators).transact(
+        {"from": validator_proxy_owner}
+    )
+    return validator_proxy_contract
+
+
+@pytest.fixture(scope="session")
+def proxy_validators(accounts):
+    return accounts[:5]
+
+
+def test_update_validators(validator_proxy_contract, validator_proxy_owner, accounts):
+    validators = accounts[:5]
+    validator_proxy_contract.functions.updateValidators(validators).transact(
+        {"from": validator_proxy_owner}
+    )
+
+
+def test_update_validators_not_system(
+    validator_proxy_contract, validator_proxy_owner, accounts
+):
+    validators = accounts[:5]
+    sender = accounts[4]
+    assert sender != validator_proxy_owner
+    with pytest.raises(eth_tester.exceptions.TransactionFailed):
+        validator_proxy_contract.functions.updateValidators(validators).transact(
+            {"from": sender}
+        )
+
+
+def test_number_of_validators(validator_proxy_with_validators, proxy_validators):
+    assert validator_proxy_with_validators.functions.numberOfValidators().call() == len(
+        proxy_validators
+    )
+
+
+def test_get_validators(validator_proxy_with_validators, proxy_validators):
+    assert (
+        validator_proxy_with_validators.functions.getValidators().call()
+        == proxy_validators
+    )
+
+
+def test_is_validator(validator_proxy_with_validators, proxy_validators, accounts):
+    for validator in proxy_validators:
+        assert (
+            validator_proxy_with_validators.functions.isValidator(validator).call()
+            is True
+        )
+
+    non_validator = accounts[7]
+    assert non_validator not in proxy_validators
+    assert (
+        validator_proxy_with_validators.functions.isValidator(non_validator).call()
+        is False
+    )

--- a/contracts/tests/test_validator_proxy.py
+++ b/contracts/tests/test_validator_proxy.py
@@ -2,21 +2,6 @@ import pytest
 import eth_tester.exceptions
 
 
-@pytest.fixture()
-def validator_proxy_with_validators(
-    validator_proxy_contract, validator_proxy_owner, proxy_validators
-):
-    validator_proxy_contract.functions.updateValidators(proxy_validators).transact(
-        {"from": validator_proxy_owner}
-    )
-    return validator_proxy_contract
-
-
-@pytest.fixture(scope="session")
-def proxy_validators(accounts):
-    return accounts[:5]
-
-
 def test_update_validators(validator_proxy_contract, validator_proxy_owner, accounts):
     validators = accounts[:5]
     validator_proxy_contract.functions.updateValidators(validators).transact(


### PR DESCRIPTION
should close: https://github.com/trustlines-protocol/blockchain/issues/140
based on https://github.com/trustlines-protocol/blockchain/pull/144
Just look at two last commits.
Implements the interface of https://github.com/poanetwork/poa-bridge-contracts/blob/master/contracts/IBridgeValidators.sol
However, `function requiredSignatures() public view returns(uint256);` had to be modified not to be `view` since it calls another contract. I do not expect this to be problem, but you should confirm @saschagoebel  