### PR TITLE
Do not load .nvm/nvm.sh when installing the bridge

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ commands:
       - run:
           name: Configuring PATH
           command: |
-            echo 'export PATH=~/bin:~/repo/bridge-venv/bin:${PATH}; . ~/.nvm/nvm.sh' >> ${BASH_ENV}
+            echo 'export PATH=~/bin:~/repo/bridge-venv/bin:${PATH}' >> ${BASH_ENV}
             echo 'export VIRTUAL_ENV=~/repo/bridge-venv' >> ${BASH_ENV}
 
   upload-docker-image:

--- a/bridge-deploy/requirements.txt
+++ b/bridge-deploy/requirements.txt
@@ -8,3 +8,4 @@ flake8
 black
 mypy
 pre-commit
+nodeenv


### PR DESCRIPTION
The makefile installs it's own version of node via nodeenv. This conflicts with
nvm and makes the next shell script bail out with:

,----
| nvm is not compatible with the npm config "prefix" option: currently set to
| "/home/circleci/repo/bridge-venv"
| Run `npm config delete prefix` or `nvm use --delete-prefix v10.14.2 --silent` to
| unset it.
`----

Also make nodeenv dependency explicit. It was previously installed as a
dependency node pre-commit.