### PR TITLE
Use 'petersburg' as evm target version

### DIFF
--- a/auction-deploy/Makefile
+++ b/auction-deploy/Makefile
@@ -9,7 +9,7 @@ test: install
 	$(VIRTUAL_ENV)/bin/pytest tests
 
 compile: install-requirements
-	$(VIRTUAL_ENV)/bin/deploy-tools compile -d ../contracts/contracts
+	$(VIRTUAL_ENV)/bin/deploy-tools compile --evm-version petersburg -d ../contracts/contracts
 	$(VIRTUAL_ENV)/bin/python scripts/pack_contracts.py build/contracts.json auction_deploy/contracts.json
 
 build: compile

--- a/auction-deploy/pytest.ini
+++ b/auction-deploy/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --evm-version petersburg

--- a/contracts/pytest.ini
+++ b/contracts/pytest.ini
@@ -1,2 +1,5 @@
 [pytest]
 addopts = --evm-version petersburg
+
+markers =
+    slow: mark a test as taking a lot of time

--- a/contracts/pytest.ini
+++ b/contracts/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --evm-version petersburg

--- a/validator-set-deploy/Makefile
+++ b/validator-set-deploy/Makefile
@@ -9,7 +9,7 @@ test: install
 	$(VIRTUAL_ENV)/bin/pytest tests
 
 compile: install-requirements
-	$(VIRTUAL_ENV)/bin/deploy-tools compile -d ../contracts/contracts
+	$(VIRTUAL_ENV)/bin/deploy-tools compile --evm-version petersburg -d ../contracts/contracts
 	$(VIRTUAL_ENV)/bin/python scripts/pack_contracts.py build/contracts.json validator_set_deploy/contracts.json
 
 build: compile

--- a/validator-set-deploy/pytest.ini
+++ b/validator-set-deploy/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --evm-version petersburg


### PR DESCRIPTION
I didn't touch the bridge, but everything else should now use petersburg.