### PR TITLE
fix networkID in chain spec file

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ These are the steps to run a node as a simple user.
 Independently of whether you created an account or not, you can start a node to sync with the trustlines chain with the following command:
 
 ```sh
-parity --chain trustlines-spec.json -d user_node --auto-update=none --no-download --network-id=4874
+parity --chain trustlines-spec.json -d user_node --auto-update=none --no-download
 ```
 
 #### Setup For Validators Using Only CLI
@@ -243,13 +243,13 @@ These are the steps to run a node as a validator, make sure you are a validator 
 If you just created an account following the "Creating an account" section and stored your password in the file "password.pwd", you can start a node with the following command, replacing [address] with your address given during account creation:
 
 ```sh
-parity --chain trustlines-spec.json -d validator_node --auto-update=none --no-download --password=password.pwd --max-peers=100 --network-id=4874 --author=[address] --engine-signer=[address] --force-sealing --reseal-on-txs=none --min-gas-price="1" --tx-queue-per-sender=100
+parity --chain trustlines-spec.json -d validator_node --auto-update=none --no-download --password=password.pwd --max-peers=100 --author=[address] --engine-signer=[address] --force-sealing --reseal-on-txs=none --min-gas-price="1" --tx-queue-per-sender=100
 ```
 
 Otherwise, you need to adjust some parameters. You need to provide the path to your private key in "--keys-path=[path]", the path to your password protecting this key in "--password=[path]" as well as your address in "--author=[address]" and "--engine-signer=[address]"
 
 ```sh
-parity --chain trustlines-spec.json -d validator_node --auto-update=none --no-download --keys-path=[path/to/keys] --password=[path/to/password] --max-peers=100 --network-id=4874 --author=[address] --engine-signer=[address] --force-sealing --reseal-on-txs=none --min-gas-price="1" --tx-queue-per-sender=100
+parity --chain trustlines-spec.json -d validator_node --auto-update=none --no-download --keys-path=[path/to/keys] --password=[path/to/password] --max-peers=100 --author=[address] --engine-signer=[address] --force-sealing --reseal-on-txs=none --min-gas-price="1" --tx-queue-per-sender=100
 ```
 
 ---

--- a/config/trustlines-spec.json
+++ b/config/trustlines-spec.json
@@ -89,7 +89,7 @@
         "gasLimitBoundDivisor": "0x400",
         "maximumExtraDataSize": "0x20",
         "minGasLimit": "0xF4240",
-        "networkID": "0x4874",
+        "networkID": "0x130A",
         "chainID": "0x4874",
         "eip155Transition": 0,
         "validateChainIdTransition": 0,

--- a/config/user-config.toml
+++ b/config/user-config.toml
@@ -10,5 +10,3 @@ no_download = true
 
 [network]
 port = 30300
-# Network ID of the chain will be overridden to: 4874
-id = 4874

--- a/config/validator-config.toml
+++ b/config/validator-config.toml
@@ -17,8 +17,6 @@ password = ["path/to/password"]
 port = 30300
 # Parity will maintain at most 100 peers.
 max_peers = 100
-# Network ID of the chain will be overridden to: 4874
-id = 4874
 
 [mining]
 # Account address to receive reward when block is mined.


### PR DESCRIPTION
The networkID was previously set to the hexadecimal value 0x4874 inside the
chain spec file and was overwritten to decimal value 4874 inside the user config
file or via command line arguments.

We now set the networkID to hexadecimal '0x130A', which is just 4874. That way
we can get rid of the setting in the user config and can get rid of the
additional --network-id command line argument.