### PR TITLE
Install pip, wheel, setuptools beforehand

### DIFF
--- a/auction-deploy/Makefile
+++ b/auction-deploy/Makefile
@@ -21,6 +21,7 @@ install: install-requirements compile
 	$(VIRTUAL_ENV)/bin/pip install -c constraints.txt -e .
 
 .installed: constraints.txt requirements.txt $(VIRTUAL_ENV)
+	$(VIRTUAL_ENV)/bin/pip install -c constraints.txt pip wheel setuptools
 	$(VIRTUAL_ENV)/bin/pip install -c constraints.txt -r requirements.txt
 	@echo "This file controls for make if the requirements in your virtual env are up to date" > $@
 


### PR DESCRIPTION
Otherwise we may end up with 'Failed building wheel' warnings being
printed during the installation.

I only noticed these while installing on a fresh machine. If you
already have wheels in your pip cache, these warnings will not be
printed.