### PR TITLE
Use absolute paths for bridge deploy tool

### DIFF
--- a/bridge-deploy/bridge_deploy/utils.py
+++ b/bridge-deploy/bridge_deploy/utils.py
@@ -1,14 +1,17 @@
+from os import path
 import json
+
+script_directory = path.dirname(path.realpath(__file__))
 
 
 def load_poa_contract(contract_name):
     with open(
-        f"../poa-bridge-contracts/build/contracts/{contract_name}.json"
+        f"{script_directory}/../../poa-bridge-contracts/build/contracts/{contract_name}.json"
     ) as json_file:
         return json.load(json_file)
 
 
-def load_build_contract(contract_name, path="./build/", file_name="contracts"):
-    with open(f"{path}{file_name}.json") as json_file:
+def load_build_contract(contract_name, file_name="contracts"):
+    with open(f"{script_directory}/../build/{file_name}.json") as json_file:
         contract_data = json.load(json_file)
         return contract_data[contract_name]


### PR DESCRIPTION
The directory where to search for the compiled contracts was given as relative path. This does not work, when executing the tool from somewhere else, like it is the case for the e2e tests.