### PR TITLE
Remove eip98 for spec file

### DIFF
--- a/config/trustlines-spec.json
+++ b/config/trustlines-spec.json
@@ -101,7 +101,6 @@
         "eip160Transition": "0x0",
         "eip161abcTransition": "0x0",
         "eip161dTransition": "0x0",
-        "eip98Transition": "0x7fffffffffffff",
         "eip145Transition": "0x2B08BA",
         "eip1014Transition": "0x2B08BA",
         "eip1052Transition": "0x2B08BA",


### PR DESCRIPTION
For EIP98, I copied it from the ethereum chain spec, but it was removed in November 2018: https://github.com/paritytech/parity-ethereum/commit/34d22a35ddeb88990899355d8dc1fb1f301bb108#diff-09e1141f3610b5496b23dd6fa862d325