### PR TITLE
Combine and simplify home reward and bridge deploy

### DIFF
--- a/tools/bridge-deploy/tests/conftest.py
+++ b/tools/bridge-deploy/tests/conftest.py
@@ -30,16 +30,5 @@ def home_bridge_validators_contract(web3):
 
 
 @pytest.fixture
-def home_bridge_deployment_result(web3):
-    deployment_result = deploy_home_bridge_contract(web3=web3)
-    return deployment_result
-
-
-@pytest.fixture
-def home_bridge_contract(home_bridge_deployment_result):
-    return home_bridge_deployment_result.home_bridge
-
-
-@pytest.fixture
-def home_bridge_proxy_contract(home_bridge_deployment_result):
-    return home_bridge_deployment_result.home_bridge_proxy
+def home_bridge_contract(web3):
+    return deploy_home_bridge_contract(web3=web3)

--- a/tools/bridge-deploy/tests/test_cli.py
+++ b/tools/bridge-deploy/tests/test_cli.py
@@ -10,13 +10,6 @@ def runner():
     return CliRunner()
 
 
-def test_deploy_reward(runner):
-
-    result = runner.invoke(main, args="deploy-reward --jsonrpc test")
-
-    assert result.exit_code == 0
-
-
 def test_deploy_bridge_validators(runner):
 
     result = runner.invoke(
@@ -34,15 +27,30 @@ def test_deploy_bridge_validators(runner):
 def test_deploy_home(
     runner, chain, block_reward_contract, home_bridge_validators_contract
 ):
-
     result = runner.invoke(
         main,
         args=(
             "deploy-home"
             " --jsonrpc test "
-            f" --validator-set-address {home_bridge_validators_contract.address}"
-            f" --block-reward-address {block_reward_contract.address}"
+            f" --bridge-validators-address {home_bridge_validators_contract.address}"
             f" --owner-address {chain.get_accounts()[0]}"
+        ),
+    )
+
+    assert result.exit_code == 0
+
+
+def test_deploy_home_custom_block_reward_amount(
+    runner, chain, block_reward_contract, home_bridge_validators_contract
+):
+    result = runner.invoke(
+        main,
+        args=(
+            "deploy-home"
+            " --jsonrpc test "
+            f" --bridge-validators-address {home_bridge_validators_contract.address}"
+            f" --owner-address {chain.get_accounts()[0]}"
+            " --block-reward-amount 1"
         ),
     )
 


### PR DESCRIPTION
Close #194

**Warning!!!**
At the moment experiments couldn't verify what the `msg.sender` address would be for the reward contract. By the current state the bridge proxy address is enabled on the initialization of the reward contract. Probably this must be changed to the implementation.