### PR TITLE
Enhance quickstart

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -310,6 +310,44 @@ jobs:
             make test
             cd ../..
 
+  build-quickstart-image:
+    executor: ubuntu-builder
+    environment:
+      LOCAL_IMAGE: quickstart
+    steps:
+      - setup_remote_docker
+      - checkout
+      - run:
+          name: Build quickstart image
+          command: |
+            make -C tools/quickstart build-docker-image
+      - run:
+          name: Save quickstart image
+          command: |
+            mkdir -p ~/images
+            docker save --output ~/images/$LOCAL_IMAGE.tar $LOCAL_IMAGE
+            du -hc ~/images
+      - persist_to_workspace:
+          root: "~"
+          paths:
+            - images
+
+  deploy-quickstart-image:
+    executor: ubuntu-builder
+    environment:
+      LOCAL_IMAGE: quickstart
+    working_directory: ~/repo
+    steps:
+      - run:
+          name: set DOCKER_REPO
+          command: |
+            echo ': \"${DOCKER_REPO:=trustlines/quickstart}\"' >> ${BASH_ENV}
+          # this allows us to set DOCKER_REPO from circleci when building in a
+          # fork. makes testing easier.
+
+      - upload-docker-image
+
+
   build-docker-image:
     executor: ubuntu-builder
     environment:
@@ -429,6 +467,7 @@ workflows:
             - install-bridge
 
       - build-docker-image
+      - build-quickstart-image
 
       - deploy-docker-image:
           filters:
@@ -443,6 +482,18 @@ workflows:
             - install-contracts
             - pytest-contracts
             - build-docker-image
+          context: docker-credentials
+
+      - deploy-quickstart-image:
+          filters:
+            branches:
+              only:
+                - master
+                - pre-release
+          requires:
+            - build-quickstart-image
+            - run-black
+            - run-flake8
           context: docker-credentials
 
       - compare-docker-image:

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+trustlines/
+submodules/
+venv/

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 VIRTUAL_ENV ?= $(shell pwd)/venv
 
-SUBDIRS = tools/auction-deploy tools/bridge-deploy tools/validator-set-deploy contracts
+SUBDIRS = tools/auction-deploy tools/bridge-deploy tools/validator-set-deploy tools/quickstart contracts
 
 .PHONY: help
 help:

--- a/tools/quickstart/Dockerfile
+++ b/tools/quickstart/Dockerfile
@@ -1,0 +1,44 @@
+# This can be build with the following command:
+#
+#   docker build -t quickstart ../.. -f Dockerfile
+#
+# we use an intermediate image to build this image. it will make the resulting
+# image a bit smaller.
+
+FROM ubuntu:18.04@sha256:f08638ec7ddc90065187e7eabdfac3c96e5ff0f6b2f1762cf31a4f49b53000a5 as base
+FROM base as builder
+# python needs LANG
+ENV LANG C.UTF-8
+ENV PIP_DISABLE_PIP_VERSION_CHECK 1
+
+RUN apt-get update \
+    && apt-get install -y apt-utils python3 python3-distutils python3-dev python3-venv build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN python3 -m venv /opt/quickstart/
+ENV PATH="/opt/quickstart/bin:${PATH}"
+
+WORKDIR /src
+
+# enable docker to cache some install steps
+COPY tools/quickstart/constraints.txt /src/
+RUN pip install -c constraints.txt pip wheel setuptools
+COPY tools/quickstart/requirements.txt /src/
+# remove development dependencies from the end of the file
+RUN sed -i -e '/development dependencies/q' requirements.txt
+RUN pip install -c constraints.txt -r requirements.txt
+
+COPY tools/quickstart /src/
+# we need to copy the symlinked file again, otherwise we have a symlink that points to nowhere
+COPY tools/quickstart/constraints.txt /src/
+RUN pip install -c constraints.txt .
+
+FROM base as runner
+ENV LANG C.UTF-8
+RUN apt-get update \
+    && apt-get install -y apt-utils python3 \
+    && rm -rf /var/lib/apt/lists/*
+
+FROM runner
+COPY --from=builder /opt/quickstart /opt/quickstart
+ENV PATH="/opt/quickstart/bin:${PATH}"

--- a/tools/quickstart/Makefile
+++ b/tools/quickstart/Makefile
@@ -1,0 +1,31 @@
+TOP_LEVEL=$(shell cd ../..; pwd)
+VIRTUAL_ENV ?= $(TOP_LEVEL)/venv
+
+lint: install
+	$(VIRTUAL_ENV)/bin/flake8 quickstart setup.py
+	$(VIRTUAL_ENV)/bin/black --check quickstart setup.py
+
+test:
+	@echo "We don't have any tests for the quickstart folder."
+
+install-requirements: .installed
+
+install: install-requirements
+	$(VIRTUAL_ENV)/bin/pip install -c constraints.txt -e .
+
+.installed: constraints.txt requirements.txt $(VIRTUAL_ENV)
+	$(VIRTUAL_ENV)/bin/pip install -c constraints.txt pip wheel setuptools
+	$(VIRTUAL_ENV)/bin/pip install -c constraints.txt -r requirements.txt
+	@echo "This file controls for make if the requirements in your virtual env are up to date" > $@
+
+$(VIRTUAL_ENV):
+	python3 -m venv $@
+
+clean:
+	rm -rf build .tox .mypy_cache .pytest_cache */__pycache__ *.egg-info
+	rm -f .installed
+
+build-docker-image::
+	docker build -t quickstart ../.. -f Dockerfile
+
+.PHONY: install install-requirements test lint compile build clean build-docker-image

--- a/tools/quickstart/README.md
+++ b/tools/quickstart/README.md
@@ -1,0 +1,10 @@
+# Overview
+
+This directory contains some short python scripts which are used by
+the quickstart script.
+
+At the moment it's being used to import a raw private key and a
+keystore file as parity account.
+
+The quickstart script uses these scripts via the public
+trustlines/quickstart image.

--- a/tools/quickstart/constraints.txt
+++ b/tools/quickstart/constraints.txt
@@ -1,0 +1,1 @@
+../../constraints.txt

--- a/tools/quickstart/quickstart/cli.py
+++ b/tools/quickstart/quickstart/cli.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+
+"""import private key or keystore file as parity account"""
+
+import sys
+import os
+import re
+import json
+from eth_account import Account
+import click
+
+
+class TrustlinesFiles:
+    def __init__(self, password_file, address_file, keystore_file):
+        self.password_file = password_file
+        self.address_file = address_file
+        self.keystore_file = keystore_file
+
+    def store(self, account, password):
+        # Instead of just copying the file, we encrypt it again since the
+        # file itself may use scrypt as key derivative function which
+        # parity can't handle
+        json_account = account.encrypt(password, kdf="pbkdf2")
+
+        os.makedirs(os.path.dirname(os.path.abspath(self.keystore_file)), exist_ok=True)
+        with open(self.keystore_file, "w") as f:
+            f.write(json.dumps(json_account))
+
+        with open(self.password_file, "w") as f:
+            f.write(password)
+
+        with open(self.address_file, "w") as f:
+            f.write(account.address)
+
+
+def import_keystore_file(trustline_files, keystore_input_file):
+    keyfile_dict = json.loads(open(keystore_input_file, "rb").read())
+
+    while 1:
+        password = click.prompt(text="Password", hide_input=True)
+        try:
+            account = Account.from_key(Account.decrypt(keyfile_dict, password))
+            break
+        except ValueError:
+            click.echo("The password you entered is wrong. Please try again.")
+
+    trustline_files.store(account, password)
+    sys.exit(0)
+
+
+def read_private_key():
+    while 1:
+        privkey = click.prompt(text="Private key (hex encodded)", hide_input=True)
+        if re.fullmatch("[0-9a-fA-F]{64}", privkey):
+            return privkey
+        click.echo(
+            "The private key muss be entered as hex encoded string. Please try again."
+        )
+
+
+def read_password():
+    while 1:
+        password = click.prompt(text="Password", hide_input=True)
+        password2 = click.prompt(text="Password (repeat)", hide_input=True)
+        if password == password2:
+            return password
+        click.echo("Passwords do not match. Please try again.")
+
+
+def import_private_key(trustline_files):
+    private_key = read_private_key()
+    account = Account.from_key(private_key)
+    click.echo(f"Read private key for address {account.address}")
+    password = read_password()
+
+    trustline_files.store(account, password)
+
+
+def make_trustlines_files():
+    password_file, address_file, keystore_file = sys.argv[1:4]
+    return TrustlinesFiles(
+        password_file=password_file,
+        address_file=address_file,
+        keystore_file=keystore_file,
+    )
+
+
+def qs_import_keystore_file():
+    if len(sys.argv) != 5:
+        click.echo(
+            "Usage: qs-import-keystore-file PASSWORD_FILE ADDRESS_FILE KEYSTORE_FILE KEYSTORE_INPUT_FILE"
+        )
+        sys.exit(1)
+    import_keystore_file(make_trustlines_files(), keystore_input_file=sys.argv[4])
+
+
+def qs_import_private_key():
+    if len(sys.argv) != 4:
+        click.echo(
+            "Usage: qs-import-private-key PASSWORD_FILE ADDRESS_FILE KEYSTORE_FILE"
+        )
+        sys.exit(1)
+
+    import_private_key(make_trustlines_files())

--- a/tools/quickstart/requirements.txt
+++ b/tools/quickstart/requirements.txt
@@ -1,0 +1,4 @@
+eth_account
+click
+# development dependencies
+-r ../../requirements-dev.txt

--- a/tools/quickstart/setup.cfg
+++ b/tools/quickstart/setup.cfg
@@ -1,0 +1,15 @@
+[metadata]
+name = trustlines-quickstart
+version = 0.1.0
+description = short helper scripts for the quickstart script
+
+[options]
+install_requires =
+  eth_account
+  click
+packages = quickstart
+
+[options.entry_points]
+console_scripts=
+    qs-import-private-key = quickstart.cli:qs_import_private_key
+    qs-import-keystore-file = quickstart.cli:qs_import_keystore_file

--- a/tools/quickstart/setup.py
+++ b/tools/quickstart/setup.py
@@ -1,0 +1,4 @@
+from setuptools import setup
+
+# configuration is read from setup.cfg
+setup()


### PR DESCRIPTION
This enable the quickstart script to import an existing private key or keystore file as parity account. It uses a new docker image to do that.

Implements #186, #187, #188 

Supercedes PR #203  
