### PR TITLE
Try to distinguish "wrong password" from "malformed keystore file"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,6 +167,29 @@ jobs:
           name: Run pytest
           command: pytest contracts/tests
 
+  test-quickstart:
+    executor: ubuntu-builder
+    steps:
+      - checkout
+      - restore_cache:
+          key: quickstart-venv-{{ checksum "tools/quickstart/constraints.txt" }}-{{ checksum "tools/quickstart/requirements.txt"}}-{{ checksum "requirements-dev.txt"}}
+      - run:
+          name: Install requirements
+          command: |
+            make -C tools/quickstart install-requirements
+      - save_cache:
+          key: quickstart-venv-{{ checksum "tools/quickstart/constraints.txt" }}-{{ checksum "tools/quickstart/requirements.txt"}}-{{ checksum "requirements-dev.txt"}}
+          paths:
+            - venv
+      - run:
+          name: Install tools/quickstart
+          command: |
+            make -C tools/quickstart install
+      - run:
+          name: Run tests
+          command: |
+            make -C tools/quickstart test
+
   mypy-auction:
     executor: ubuntu-builder
     steps:
@@ -468,7 +491,7 @@ workflows:
 
       - build-docker-image
       - build-quickstart-image
-
+      - test-quickstart
       - deploy-docker-image:
           filters:
             branches:
@@ -491,6 +514,7 @@ workflows:
                 - master
                 - pre-release
           requires:
+            - test-quickstart
             - build-quickstart-image
             - run-black
             - run-flake8

--- a/tools/quickstart/Makefile
+++ b/tools/quickstart/Makefile
@@ -5,8 +5,8 @@ lint: install
 	$(VIRTUAL_ENV)/bin/flake8 quickstart setup.py
 	$(VIRTUAL_ENV)/bin/black --check quickstart setup.py
 
-test:
-	@echo "We don't have any tests for the quickstart folder."
+test: install
+	$(VIRTUAL_ENV)/bin/pytest tests
 
 install-requirements: .installed
 

--- a/tools/quickstart/quickstart/cli.py
+++ b/tools/quickstart/quickstart/cli.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 """import private key or keystore file as parity account"""
 
 import sys
@@ -33,6 +31,10 @@ class TrustlinesFiles:
             f.write(account.address)
 
 
+def is_wrong_password_error(err):
+    return type(err) is ValueError and str(err) == "MAC mismatch"
+
+
 def import_keystore_file(trustline_files, keystore_input_file):
     keyfile_dict = json.loads(open(keystore_input_file, "rb").read())
 
@@ -41,9 +43,12 @@ def import_keystore_file(trustline_files, keystore_input_file):
         try:
             account = Account.from_key(Account.decrypt(keyfile_dict, password))
             break
-        except ValueError:
-            click.echo("The password you entered is wrong. Please try again.")
-
+        except Exception as err:
+            if is_wrong_password_error(err):
+                click.echo("The password you entered is wrong. Please try again.")
+            else:
+                click.echo(f"Error: malformed keystore file: {repr(err)}")
+                sys.exit(1)
     trustline_files.store(account, password)
     sys.exit(0)
 

--- a/tools/quickstart/tests/test_cli.py
+++ b/tools/quickstart/tests/test_cli.py
@@ -1,0 +1,14 @@
+from eth_account import Account
+
+from quickstart import cli
+
+
+def test_is_wrong_password():
+    def try_wrong_password():
+        keystore_dict = Account.from_key("0" * 64).encrypt("password")
+        try:
+            Account.decrypt(keystore_dict, "wrong password")
+        except Exception as err:
+            return err
+
+    assert cli.is_wrong_password_error(try_wrong_password())


### PR DESCRIPTION
Previously we assumed a ValueError is raised iff the user entered the
wrong password. It could be the case that a ValueError is raised
because the keystore file is malformed.

We now distinguish as good as we can between these two cases.

This now also comes with a test, in case the error being raised does
change when upgrading eth_account.

The circle ci configuration only uses a single job. We may do this for
the other jobs as well where it makes sense. It's much simpler. We
rely on the makefile creating the virtualenv.

Also, we need to take the checksum of the requirements-dev.txt file
into account for the other jobs. This file is being included via '-r
../../requirements-dev.txt' from the other requirements.txt files.

We do this for the new job, but it still has to be changed for the
others.