### PR TITLE
Fix typo in quickstart script

### DIFF
--- a/quickstart.sh
+++ b/quickstart.sh
@@ -348,7 +348,7 @@ EOF
 
   printmsg <<EOF
 
-Parity node as started and is running in background!
+The Parity client has started and is running in background!
 
 EOF
 }


### PR DESCRIPTION
Fix typo (as->has) and use same wording as in other messages (Parity node -> Parity client)