### PR TITLE
Enable shellcheck on circleci and as pre-commit hook

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,6 +106,10 @@ jobs:
           command: |
             pre-commit run -a shfmt
       - run:
+          name: Run shellcheck
+          command: |
+            pre-commit run -a shellcheck
+      - run:
           name: Check for large files
           command: |
             pre-commit run -a check-added-large-files
@@ -133,15 +137,6 @@ jobs:
           name: Run trailing-whitespace fixer
           command: |
             pre-commit run -a trailing-whitespace
-
-  run-shellcheck:
-    executor: ubuntu-builder
-    steps:
-      - checkout
-      - run:
-          name: Shellcheck the quickstart script
-          command: |
-            shellcheck quickstart.sh
 
   run-black:
     executor: ubuntu-builder
@@ -518,7 +513,6 @@ workflows:
   version: 2
   default:
     jobs:
-      - run-shellcheck
       - pre-commit-checks
       - run-black
       - run-flake8
@@ -562,7 +556,6 @@ workflows:
           requires:
             - solium-contracts
             - pre-commit-checks
-            - run-shellcheck
             - run-black
             - run-flake8
             - install-contracts
@@ -580,7 +573,6 @@ workflows:
             - test-quickstart
             - build-quickstart-image
             - pre-commit-checks
-            - run-shellcheck
             - run-black
             - run-flake8
           context: docker-credentials
@@ -607,7 +599,6 @@ workflows:
             - approve-the-release
             - solium-contracts
             - pre-commit-checks
-            - run-shellcheck
             - run-black
             - run-flake8
             - install-contracts

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,8 @@ repos:
   rev: 1edc6d3ab9380e17eb01a601551283cf7bc23f2b
   hooks:
     - id: shfmt
+    - id: shellcheck
+      exclude: ^docker/parity_wrapper.sh$
 
 -   repo: https://github.com/ambv/black
     rev: 19.3b0


### PR DESCRIPTION
We exclude the parity_wrapper.sh script for now as I'm not confident
that the changes required there do work and I don't want to spend time
testing it.