### PR TITLE
Add solidity syntax highlighting in github

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sol linguist-language=Solidity


### PR DESCRIPTION
Just skimmed through the contracts via github and noticed that syntax highlighting for solidity is not enabled.