### PR TITLE
Purge confirmations from ex validators

### DIFF
--- a/contracts/.soliumrc.json
+++ b/contracts/.soliumrc.json
@@ -5,7 +5,7 @@
   ],
   "rules": {
     "indentation": [
-      "error",
+      "warning",
       4
     ],
     "function-order": "error",


### PR DESCRIPTION
This makes sure that only active confirmations from active validators are taken into account.

At the moment this doesn't handle the case, where the number of confirmations would already suffice when the validator set shrinks.
