### PR TITLE
Support for dotenv files to easily configure the docker stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+.env
 
 # Spyder project settings
 .spyderproject

--- a/tools/bridge/.env.example
+++ b/tools/bridge/.env.example
@@ -1,0 +1,11 @@
+# The Home RPC Address. Should point to a Trustlines RPC Node
+HOME_RPC_URL=http://node_home:8545
+
+# The Foreign RPC Address. Should point to a Mainnet / Ropsten RPC Node
+FOREIGN_RPC_URL=http://node_foreign:8545
+
+# The Address of the Token Contract on the Foreign Network
+TOKEN_CONTRACT_ADDRESS=0x20fE562d797A42Dcb3399062AE9546cd06f63280
+
+# The Address of the Bridge Contract on the Foreign Network
+FOREIGN_BRIDGE_CONTRACT_ADDRESS=0x83a30dD54a744c60190548af8d983719116eff4a

--- a/tools/bridge/Dockerfile
+++ b/tools/bridge/Dockerfile
@@ -11,10 +11,4 @@ pip install -c constraints.txt pip wheel setuptools && \
 pip install -c constraints.txt -r requirements.txt && \
 pip install -c constraints.txt -e .
 
-# TODO: Replace with ENV Config or mounted file
-RUN echo 'home_rpc_url = "http://node_home:8545"' > config.toml
-RUN echo 'foreign_rpc_url = "http://node_foreign:8545"' >> config.toml
-RUN echo 'token_contract_address = "0x20fE562d797A42Dcb3399062AE9546cd06f63280"' >> config.toml
-RUN echo 'foreign_bridge_contract_address = "0x83a30dD54a744c60190548af8d983719116eff4a"' >> config.toml
-
-CMD [ "tlbc-bridge", "--config", "./config.toml" ]
+CMD [ "tlbc-bridge" ]

--- a/tools/bridge/Makefile
+++ b/tools/bridge/Makefile
@@ -35,4 +35,4 @@ clean:
 	rm -rf build .tox .mypy_cache .pytest_cache */__pycache__ *.egg-info
 	rm -f .installed
 
-.PHONY: install install-requirements test lint compile build format clean
+.PHONY: install install-requirements test lint compile build format clean start

--- a/tools/bridge/Makefile
+++ b/tools/bridge/Makefile
@@ -15,6 +15,9 @@ test: install-requirements install
 build: install
 	$(VIRTUAL_ENV)/bin/python setup.py sdist
 
+start: install
+	$(VIRTUAL_ENV)/bin/tlbc-bridge
+
 install-requirements: .installed
 
 install: install-requirements compile

--- a/tools/bridge/README.md
+++ b/tools/bridge/README.md
@@ -9,28 +9,48 @@ The docker container needs to be built from the root path, so
 docker build --file ./Dockerfile ../../
 ```
 
-Running
--------
-
-Just mix & match all the components you want to run.
-
-### Start Development Stack
+Development
+-----------
+### Start the development/testnet light nodes
 ```bash
-docker-compose --project-name tlbc-bridge --file ./docker/docker-compose.yml --file ./docker/docker-compose-nodes-development.yml up --detach
+docker-compose --project-name tlbc-bridge -f ./docker/docker-compose-nodes-development.yml up
 ```
 
-### View Logs
+### Run the application locally
+
 ```bash
-docker-compose --project-name tlbc-bridge --file ./docker/docker-compose.yml --file ./docker/docker-compose-nodes-development.yml logs -f
+make start
 ```
 
-### Stop Development Stack
+#### Local configuration
+You can overwrite the .env parameters with predefined environment variables, so you can have your .env point to the docker hosts while locally using
 ```bash
-docker-compose --project-name tlbc-bridge --file ./docker/docker-compose.yml --file ./docker/docker-compose-nodes-development.yml down
+HOME_RPC_URL=http://localhost:8546 FOREIGN_RPC_URL=http://localhost:8545 make start
+```
+
+### **or** start the Docker file
+
+```bash
+docker-compose --project-name tlbc-bridge -f ./docker/docker-compose.yml build
+docker-compose --project-name tlbc-bridge -f ./docker/docker-compose.yml up
 ```
 
 Production
 ----------
-For the production stack, just replace the development nodes compose file with the production one.
+### Start Nodes & Service
+```bash
+docker-compose --project-name tlbc-bridge --file ./docker/docker-compose.yml --file ./docker/docker-compose-nodes-production.yml build
+docker-compose --project-name tlbc-bridge --file ./docker/docker-compose.yml --file ./docker/docker-compose-nodes-production.yml up --detach
+```
+
+### View Logs
+```bash
+docker-compose --project-name tlbc-bridge --file ./docker/docker-compose.yml --file ./docker/docker-compose-nodes-production.yml logs --tail 200 -f
+```
+
+### Stop Nodes & Service
+```bash
+docker-compose --project-name tlbc-bridge --file ./docker/docker-compose.yml --file ./docker/docker-compose-nodes-production.yml down
+```
 
 **There is no production Trustlines chain yet, so this won't work**

--- a/tools/bridge/bridge/config.py
+++ b/tools/bridge/bridge/config.py
@@ -6,6 +6,10 @@ import os
 from eth_utils.toolz import merge
 from web3 import Web3
 
+from dotenv import load_dotenv
+
+load_dotenv()
+
 
 def validate_rpc_url(url: Any) -> None:
     if not isinstance(url, str):

--- a/tools/bridge/bridge/main.py
+++ b/tools/bridge/bridge/main.py
@@ -28,6 +28,14 @@ from bridge.contract_abis import MINIMAL_ERC20_TOKEN_ABI
     help="Path to a config file",
 )
 def main(config_path: str) -> None:
+    """The Trustlines Bridge Validation Server
+
+    Configuration can be made using a TOML file or via Environment Variables.
+    A dotenv (.env) file will be automatically evaluated.
+
+    See .env.example and config.py for valid configuration options and defaults.
+    """
+
     logging.basicConfig(level=logging.INFO)
 
     try:

--- a/tools/bridge/docker/docker-compose.yml
+++ b/tools/bridge/docker/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     build:
       context: ../../../
       dockerfile: tools/bridge/Dockerfile
+    env_file:
+      - ../.env
     restart: unless-stopped
     mem_limit: 512M
     mem_reservation: 16M

--- a/tools/bridge/requirements.txt
+++ b/tools/bridge/requirements.txt
@@ -4,4 +4,5 @@ gevent
 toml
 web3
 contract-deploy-tools
+python-dotenv
 -r ../../requirements-dev.txt


### PR DESCRIPTION
Support for dotenv files to easily configure the docker stack (and the local app)

- Hint: .env file is ignored, because it may contain secrets, but ln -snf .env.example .env