### PR TITLE
Measure home bridge gas usage

### DIFF
--- a/contracts/tests/bridge/test_measure_gas_home_bridge.py
+++ b/contracts/tests/bridge/test_measure_gas_home_bridge.py
@@ -28,7 +28,9 @@ def all_proxy_validators(chain):
     account_0 = chain.get_accounts()[0]
     validators = []
     for i in range(maximal_number_of_validators):
-        account_num = 20000000 + i  # do not
+        # use an offset for the account number in order to not
+        # generate the same keys we generate in the whitelist fixture
+        account_num = 20000000 + i
         new_account = chain.add_account(f"0x{account_num:064}")
         chain.send_transaction(
             {

--- a/contracts/tests/bridge/test_measure_gas_home_bridge.py
+++ b/contracts/tests/bridge/test_measure_gas_home_bridge.py
@@ -1,0 +1,120 @@
+#! pytest -s
+
+"""This is used to test the gas usage of the home bridge
+ contract. This file can be used as a standalone scripts.
+"""
+
+import pytest
+
+minimal_number_of_validators = 50
+maximal_number_of_validators = 123
+
+
+@pytest.fixture(params=[maximal_number_of_validators, minimal_number_of_validators])
+def number_of_validators(request):
+    """the number of validators."""
+    return request.param
+
+
+@pytest.fixture()
+def required_confirmations(number_of_validators):
+    """the number of confirmations required"""
+    return (number_of_validators * 50 + 99) // 100
+
+
+@pytest.fixture(scope="session")
+def all_proxy_validators(chain):
+    """list of 123 accounts that can be used as validators"""
+    account_0 = chain.get_accounts()[0]
+    validators = []
+    for i in range(maximal_number_of_validators):
+        account_num = 20000000 + i  # do not
+        new_account = chain.add_account(f"0x{account_num:064}")
+        chain.send_transaction(
+            {
+                "from": account_0,
+                "to": new_account,
+                "gas": 100000,
+                "value": 1_000_000_000,
+            }
+        )
+        validators.append(new_account)
+
+    return validators
+
+
+@pytest.fixture()
+def proxy_validators(all_proxy_validators, number_of_validators):
+    """The validators used in the proxy contract. This replaces the
+    fixture with the same name from conftest.py"""
+    return all_proxy_validators[:number_of_validators]
+
+
+@pytest.fixture
+def confirm_nth(home_bridge_contract, proxy_validators, web3):
+    """confirm a transfer by the nth validator"""
+
+    class ConfirmNth:
+        transfer_hash = "0x" + b"     transfer-hash              ".hex()
+        tx_hash = "0x" + b"     tx-hash                    ".hex()
+        amount = 20000
+        recipient = "0xFCB047cCD297048b6F31fbb2fef14001FefFa0f3"
+
+        def __call__(self, n, fail_ok=False):
+            validator = proxy_validators[n]
+            transact_args = {"from": validator}
+            if fail_ok:
+                # we pass in the gas here in order to not make it not
+                # raise while estimating gas
+                transact_args["gas"] = 2_000_000
+
+            tx_hash = home_bridge_contract.functions.confirmTransfer(
+                transferHash=self.transfer_hash,
+                transactionHash=self.tx_hash,
+                amount=self.amount,
+                recipient=self.recipient,
+            ).transact(transact_args)
+            tx_receipt = web3.eth.getTransactionReceipt(tx_hash)
+            gas = tx_receipt.gasUsed
+            print(
+                f"validator {n+1} {validator} confirmed, gas: {gas}, status: {tx_receipt.status}"
+            )
+            return gas
+
+    return ConfirmNth()
+
+
+def test_gas_cost_complete_transfer(
+    home_bridge_contract,
+    proxy_validators,
+    confirm_nth,
+    web3,
+    number_of_validators,
+    required_confirmations,
+):
+    """This walks through a complete Transfer on the home bridge and
+    checks gas usage limits
+    """
+    print(
+        f"\n=====> {number_of_validators} validators, {required_confirmations} confirmations required"
+    )
+    get_transfer_completed_events = home_bridge_contract.events.TransferCompleted.createFilter(
+        fromBlock=web3.eth.blockNumber
+    ).get_all_entries
+
+    for i in range(required_confirmations - 1):
+        gas = confirm_nth(i)
+        assert gas < 120_000
+
+    assert not get_transfer_completed_events()
+
+    # complete the transfer
+    print("Completing the transfer")
+    gas = confirm_nth(required_confirmations - 1)
+    assert gas < 400_000
+    assert get_transfer_completed_events()
+
+    print("Confirm after complete")
+    gas = confirm_nth(required_confirmations, fail_ok=True)
+    assert gas < 50000
+    print("")

--- a/contracts/tests/conftest.py
+++ b/contracts/tests/conftest.py
@@ -292,14 +292,13 @@ def almost_filled_validator_auction(
 
 @pytest.fixture(scope="session")
 def whitelist(chain, maximal_number_of_auction_participants):
-    """Every known accounts appart from accounts[0] is in the whitelist"""
-    new_chain = chain
-    for i in range(100, 100 + maximal_number_of_auction_participants):
-        new_chain.add_account(
-            "0x0000000000000000000000000000000000000000000000000000000000000" + str(i)
-        )
-
-    whitelist = new_chain.get_accounts()[1:]
+    """whitelisted well-funded accounts, accounts[0] is not in the whitelist"""
+    # some other tests do also call add_account and we do not want to
+    # include them (it just takes longer)
+    whitelist = list(chain.get_accounts()[1:10]) + [
+        chain.add_account(f"0x{i:064}")
+        for i in range(100, 100 + maximal_number_of_auction_participants)
+    ]
 
     send_ether_to_whitelisted_accounts(chain, whitelist)
 

--- a/contracts/tests/conftest.py
+++ b/contracts/tests/conftest.py
@@ -382,7 +382,7 @@ def foreign_bridge_contract(deploy_contract, tln_token_contract):
     )
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture()
 def proxy_validators(accounts):
     return accounts[:5]
 


### PR DESCRIPTION
Add tests that measure the home bridge contracts' gas usage

This is implemented as a pytest test file, but can also be run
standalone.

I will move the other bridge related tests into the newly created
tests/bridge directory later. We should have the same directory
structure like in the contracts/contracts directory.
