### PR TITLE
Upgrade web3 from 5.0.0b2 to 5.0.0b4

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -14,6 +14,7 @@ Click==7.0
 contract-deploy-tools==0.4.3
 cryptography==2.7
 cytoolz==0.9.0.1
+decorator==4.4.0
 entrypoints==0.3
 eth-abi==2.0.0b9
 eth-account==0.4.0
@@ -25,7 +26,6 @@ eth-rlp==0.1.2
 eth-tester==0.1.0b39
 eth-typing==2.1.0
 eth-utils==1.6.0
-ethpm==0.1.4a19
 flake8==3.7.7
 flake8-polyfill==1.0.2
 gevent==1.4.0
@@ -57,7 +57,6 @@ protobuf==3.8.0
 py==1.8.0
 py-ecc==1.7.0
 py-evm==0.2.0a42
-py-geth==2.1.0
 py-solc==3.2.0
 pycodestyle==2.5.0
 pycparser==2.19
@@ -67,7 +66,6 @@ pyflakes==2.1.1
 pyparsing==2.4.0
 pysha3==1.0.2
 pytest==4.6.2
-pytest-ethereum==0.1.3a6
 python-dateutil==2.8.0
 python-dotenv==0.10.3
 pytzdata==2019.1
@@ -87,7 +85,7 @@ validators==0.13.0
 varint==1.0.2
 virtualenv==16.6.0
 wcwidth==0.1.7
-web3==5.0.0b2
+web3==5.0.0b4
 websockets==7.0
 wheel==0.33.4
 zipp==0.5.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,12 +5,3 @@ pep8-naming
 pre-commit
 pytest
 setuptools_scm
-
-# The following three dependencies are missing because ethpm has a
-# dependency on web3[tester]. This is a hacky workaround. For details
-# visit:
-# https://github.com/trustlines-protocol/contract-deploy-tools/pull/38#issuecomment-499412276
-
-py-geth
-eth-tester[py-evm]
-pytest-ethereum


### PR DESCRIPTION
ethpm has been integrated into web3. That means we can get rid of the
workaround for missing dependencies.

Before upgrading to this version, the standalone ethpm package has to
be manually uninstalled.

The following PR has been merged into 5.0.0b4, which is the primary
reason for the upgrade:

  https://github.com/ethereum/web3.py/pull/1378