### PR TITLE
Add synthetic event to mark sync status of bridge

### DIFF
--- a/tools/bridge/bridge/confirmation_sender.py
+++ b/tools/bridge/bridge/confirmation_sender.py
@@ -9,6 +9,7 @@ from web3.contract import Contract
 
 from bridge.constants import HOME_CHAIN_STEP_DURATION
 from bridge.contract_validation import is_bridge_validator
+from bridge.event_fetcher import FetcherReachedHeadEvent
 
 
 class ConfirmationSender:
@@ -57,6 +58,10 @@ class ConfirmationSender:
     def send_confirmation_transactions(self):
         while True:
             transfer_event = self.transfer_event_queue.get()
+
+            if isinstance(transfer_event, FetcherReachedHeadEvent):
+                # TODO: Needs to be handled
+                continue
 
             if not is_bridge_validator(self.home_bridge_contract, self.address):
                 self.logger.warning(

--- a/tools/bridge/bridge/event_fetcher.py
+++ b/tools/bridge/bridge/event_fetcher.py
@@ -1,11 +1,16 @@
 import logging
-from time import sleep
+from time import sleep, time
 from typing import Any, Dict, List
 
 from eth_utils import to_checksum_address
 from web3 import Web3
 from web3.contract import Contract
 from web3.datastructures import AttributeDict
+
+
+class FetcherReachedHeadEvent:
+    def __init__(self):
+        self.timestamp = int(time())
 
 
 class EventFetcher:
@@ -118,5 +123,7 @@ class EventFetcher:
             events = self.fetch_some_events()
             for event in events:
                 self.event_queue.put(event)
+
             if not events:
+                self.event_queue.put(FetcherReachedHeadEvent())
                 sleep(poll_interval)

--- a/tools/bridge/bridge/event_fetcher.py
+++ b/tools/bridge/bridge/event_fetcher.py
@@ -10,7 +10,7 @@ from web3.datastructures import AttributeDict
 
 class FetcherReachedHeadEvent:
     def __init__(self):
-        self.timestamp = int(time())
+        self.timestamp = time()
 
 
 class EventFetcher:


### PR DESCRIPTION
Closes: #287

Very open for suggestions of a better name... :see_no_evil: 

The tests fail at the moment due to `gevent` when running the whole suite. I solved it locally with a monkey patch on the very top of the `conftest`. But @schmir I guess your approach with a custom `mypy` script like for the `relay` project is better/cleaner?

@schmir @jannikluhn feel free to reject this PR if it is not necessary anymore to another design change related to the event fetcher.