### PR TITLE
Index Confirmation.validator field

### DIFF
--- a/contracts/contracts/bridge/HomeBridge.sol
+++ b/contracts/contracts/bridge/HomeBridge.sol
@@ -15,7 +15,7 @@ contract HomeBridge {
         bytes32 transactionHash,
         uint256 amount,
         address recipient,
-        address validator
+        address indexed validator
     );
     event TransferCompleted(
         bytes32 transferHash,


### PR DESCRIPTION
In most cases, bridge validators will care only about confirmations
they sent themselves. Index the validator argument in the home bridge
contract so that they can filter accordingly.

see https://github.com/trustlines-protocol/blockchain/issues/294