### PR TITLE
Configure logging subsystem via the TOML file

### DIFF
--- a/tools/bridge/README.md
+++ b/tools/bridge/README.md
@@ -57,7 +57,7 @@ docker-compose --project-name tlbc-bridge --file ./docker/docker-compose.yml --f
 
 ### Configure logging via the TOML configuration file
 
-You can configure logging with by setting the 'logging' key in the
+You can configure logging by setting the 'logging' key in the
 TOML configuration file:
 
 ```toml

--- a/tools/bridge/README.md
+++ b/tools/bridge/README.md
@@ -54,3 +54,20 @@ docker-compose --project-name tlbc-bridge --file ./docker/docker-compose.yml --f
 ```
 
 **There is no production Trustlines chain yet, so this won't work**
+
+### Configure logging via the TOML configuration file
+
+You can configure logging with by setting the 'logging' key in the
+TOML configuration file:
+
+```toml
+[logging.root]
+level = "INFO"
+
+[logging.loggers."bridge.main"]
+level = "DEBUG"
+```
+
+Internally this is using python's [logging.config.dictConfig](https://docs.python.org/3/library/logging.config.html#logging.config.dictConfig).
+
+The exact schema for this key can be found [Configuration dictionary schema](https://docs.python.org/3/library/logging.config.html#logging-config-dictschema)

--- a/tools/bridge/bridge/config.py
+++ b/tools/bridge/bridge/config.py
@@ -67,6 +67,17 @@ def validate_private_key(private_key: Any) -> bytes:
     return private_key_bytes
 
 
+def validate_logging(logging_dict: Dict) -> Dict:
+    """validate the logging dictionary
+
+    We don't do much here, but instead rely on the main function to
+    catch errors from logging.config.dictConfig
+    """
+    if not isinstance(logging_dict, dict):
+        raise ValueError("logging must be a dictionary")
+    return merge({"version": 1, "incremental": True}, logging_dict)
+
+
 REQUIRED_CONFIG_ENTRIES = [
     "home_rpc_url",
     "home_bridge_contract_address",
@@ -77,6 +88,7 @@ REQUIRED_CONFIG_ENTRIES = [
 ]
 
 OPTIONAL_CONFIG_ENTRIES_WITH_DEFAULTS: Dict[str, Any] = {
+    "logging": {},
     "home_rpc_timeout": 180,
     "home_chain_gas_price": 10 * 1000000000,  # Gas price is in GWei
     "home_chain_max_reorg_depth": 1,
@@ -88,6 +100,7 @@ OPTIONAL_CONFIG_ENTRIES_WITH_DEFAULTS: Dict[str, Any] = {
 }
 
 CONFIG_ENTRY_VALIDATORS = {
+    "logging": validate_logging,
     "home_rpc_url": validate_rpc_url,
     "home_rpc_timeout": validate_non_negative_integer,
     "home_chain_gas_price": validate_non_negative_integer,


### PR DESCRIPTION
This is using logging.config.dictConfig:
https://docs.python.org/3/library/logging.config.html#logging.config.dictConfig

See https://github.com/trustlines-protocol/blockchain/issues/298 and
https://github.com/trustlines-protocol/blockchain/issues/299