### PR TITLE
Simplify interaction between TransferRecorder and task planner

### DIFF
--- a/tools/bridge/tests/test_confirmation_task_planner.py
+++ b/tools/bridge/tests/test_confirmation_task_planner.py
@@ -95,48 +95,20 @@ def completion_event(completion_events):
 
 
 @pytest.fixture
-def sync_persistence_time():
-    """The time the transfer recorder assumes the sync status will persist."""
-    return 2
-
-
-@pytest.fixture
-def recorder(sync_persistence_time):
+def recorder():
     """A transfer recorder."""
-    return TransferRecorder(sync_persistence_time)
+    return TransferRecorder()
 
 
-def test_recorder_is_in_sync_if_home_chain_is_in_sync(recorder, sync_persistence_time):
-    assert not recorder.is_in_sync(10)
-    recorder.apply_home_chain_synced_event(10)
-    assert recorder.is_in_sync(10)
-    assert recorder.is_in_sync(10 + sync_persistence_time - 0.01)
-    assert not recorder.is_in_sync(10 + sync_persistence_time + 0.01)
-
-
-def test_sync_time_can_not_be_reduced(recorder):
-    recorder.apply_home_chain_synced_event(2)
-    recorder.apply_home_chain_synced_event(2)  # this is fine
-    with pytest.raises(ValueError):
-        recorder.apply_home_chain_synced_event(1)  # this is not
-
-
-def test_recorder_plans_transfers_if_in_sync(recorder, transfer_event):
+def test_recorder_plans_transfers(recorder, transfer_event):
     recorder.apply_proper_event(transfer_event)
-    recorder.apply_home_chain_synced_event(10)
-    assert recorder.pull_transfers_to_confirm(10) == [transfer_event]
-
-
-def test_recorder_does_not_plan_transfer_if_not_in_sync(recorder, transfer_event):
-    recorder.apply_proper_event(transfer_event)
-    assert len(recorder.pull_transfers_to_confirm(10)) == 0
+    assert recorder.pull_transfers_to_confirm() == [transfer_event]
 
 
 def test_recorder_does_not_plan_transfers_twice(recorder, transfer_event):
     recorder.apply_proper_event(transfer_event)
-    recorder.apply_home_chain_synced_event(10)
-    assert recorder.pull_transfers_to_confirm(10) == [transfer_event]
-    assert len(recorder.pull_transfers_to_confirm(10)) == 0
+    assert recorder.pull_transfers_to_confirm() == [transfer_event]
+    assert len(recorder.pull_transfers_to_confirm()) == 0
 
 
 def test_recorder_does_not_plan_confirmed_transfer(recorder, transfer_hash, hashes):
@@ -148,8 +120,7 @@ def test_recorder_does_not_plan_confirmed_transfer(recorder, transfer_hash, hash
     )
     recorder.apply_proper_event(transfer_event)
     recorder.apply_proper_event(confirmation_event)
-    recorder.apply_home_chain_synced_event(10)
-    assert len(recorder.pull_transfers_to_confirm(10)) == 0
+    assert len(recorder.pull_transfers_to_confirm()) == 0
 
 
 def test_recorder_does_not_plan_completed_transfer(recorder, transfer_hash, hashes):
@@ -161,5 +132,4 @@ def test_recorder_does_not_plan_completed_transfer(recorder, transfer_hash, hash
     )
     recorder.apply_proper_event(transfer_event)
     recorder.apply_proper_event(completion_event)
-    recorder.apply_home_chain_synced_event(10)
-    assert len(recorder.pull_transfers_to_confirm(10)) == 0
+    assert len(recorder.pull_transfers_to_confirm()) == 0


### PR DESCRIPTION
We check in the task planner if the FetcherReachedHeadEvent has not
been in the queue for too long.

The handling of the sync_persistence_time can therefore be removed
from the TransferRecorder.