### PR TITLE
Validator Status Watcher

### DIFF
--- a/tools/bridge/bridge/confirmation_task_planner.py
+++ b/tools/bridge/bridge/confirmation_task_planner.py
@@ -17,6 +17,7 @@ class ConfirmationTaskPlanner:
         transfer_event_queue: Queue,
         home_bridge_event_queue: Queue,
         confirmation_task_queue: Queue,
+        is_validating: bool = True,
     ) -> None:
 
         self.recorder = TransferRecorder()
@@ -26,6 +27,13 @@ class ConfirmationTaskPlanner:
         self.home_bridge_event_queue = home_bridge_event_queue
 
         self.confirmation_task_queue = confirmation_task_queue
+
+    def start_validating(self) -> None:
+        self.recorder.start_validating()
+
+    @property
+    def is_validating(self) -> bool:
+        return self.recorder.is_validating
 
     def run(self):
         logger.debug("Starting")

--- a/tools/bridge/bridge/confirmation_task_planner.py
+++ b/tools/bridge/bridge/confirmation_task_planner.py
@@ -17,9 +17,7 @@ class ConfirmationTaskPlanner:
         transfer_event_queue: Queue,
         home_bridge_event_queue: Queue,
         confirmation_task_queue: Queue,
-        is_validating: bool = True,
     ) -> None:
-
         self.recorder = TransferRecorder()
         self.sync_persistence_time = sync_persistence_time
 

--- a/tools/bridge/bridge/main.py
+++ b/tools/bridge/bridge/main.py
@@ -71,7 +71,7 @@ def make_w3_foreign(config):
     )
 
 
-def sanity_check_home_bridge_contract(home_bridge_contract):
+def sanity_check_home_bridge_contracts(home_bridge_contract):
     validate_contract_existence(home_bridge_contract)
 
     validator_proxy_contract = get_validator_proxy_contract(home_bridge_contract)
@@ -110,7 +110,7 @@ def make_home_bridge_event_fetcher(config, home_bridge_event_queue):
     home_bridge_contract = w3_home.eth.contract(
         address=config["home_bridge_contract_address"], abi=HOME_BRIDGE_ABI
     )
-    sanity_check_home_bridge_contract(home_bridge_contract)
+    sanity_check_home_bridge_contracts(home_bridge_contract)
 
     validator_address = PrivateKey(
         config["validator_private_key"]
@@ -136,7 +136,7 @@ def make_confirmation_sender(config, confirmation_task_queue):
     home_bridge_contract = w3_home.eth.contract(
         address=config["home_bridge_contract_address"], abi=HOME_BRIDGE_ABI
     )
-    sanity_check_home_bridge_contract(home_bridge_contract)
+    sanity_check_home_bridge_contracts(home_bridge_contract)
 
     return ConfirmationSender(
         transfer_event_queue=confirmation_task_queue,

--- a/tools/bridge/bridge/transfer_recorder.py
+++ b/tools/bridge/bridge/transfer_recorder.py
@@ -12,7 +12,7 @@ from bridge.utils import compute_transfer_hash
 
 
 class TransferRecorder:
-    def __init__(self) -> None:
+    def __init__(self, is_validating: bool = True) -> None:
         self.transfer_events: Dict[Hash32, AttributeDict] = {}
 
         self.transfer_hashes: Set[Hash32] = set()
@@ -22,6 +22,14 @@ class TransferRecorder:
         self.scheduled_hashes: Set[Hash32] = set()
 
         self.home_chain_synced_until = 0.0
+
+        self.is_validating = is_validating
+
+    def start_validating(self) -> None:
+        if self.is_validating:
+            raise ValueError("Validator is already validating")
+
+        self.is_validating = True
 
     def apply_proper_event(self, event: AttributeDict) -> None:
         event_name = event.event
@@ -42,30 +50,38 @@ class TransferRecorder:
             raise ValueError(f"Got unknown event {event}")
 
     def clear_transfers(self) -> None:
-        all_stages_seen = (
-            self.transfer_hashes & self.confirmation_hashes & self.completion_hashes
-        )
-        self.transfer_hashes -= all_stages_seen
-        self.confirmation_hashes -= all_stages_seen
-        self.completion_hashes -= all_stages_seen
+        if self.is_validating:
+            transfer_hashes_to_remove = (
+                self.transfer_hashes & self.confirmation_hashes & self.completion_hashes
+            )
+        else:
+            # if we're not validating, there's no chance to see a confirmation by us
+            transfer_hashes_to_remove = self.transfer_hashes & self.completion_hashes
 
-        self.scheduled_hashes -= all_stages_seen
+        self.transfer_hashes -= transfer_hashes_to_remove
+        self.confirmation_hashes -= transfer_hashes_to_remove
+        self.completion_hashes -= transfer_hashes_to_remove
 
-        for transfer_hash in all_stages_seen:
+        self.scheduled_hashes -= transfer_hashes_to_remove
+
+        for transfer_hash in transfer_hashes_to_remove:
             self.transfer_events.pop(transfer_hash, None)
 
     def pull_transfers_to_confirm(self) -> List[AttributeDict]:
-        unconfirmed_transfer_hashes = (
-            self.transfer_hashes
-            - self.confirmation_hashes
-            - self.completion_hashes
-            - self.scheduled_hashes
-        )
-        self.scheduled_hashes |= unconfirmed_transfer_hashes
-        confirmation_tasks = [
-            self.transfer_events[transfer_hash]
-            for transfer_hash in unconfirmed_transfer_hashes
-        ]
+        if self.is_validating:
+            unconfirmed_transfer_hashes = (
+                self.transfer_hashes
+                - self.confirmation_hashes
+                - self.completion_hashes
+                - self.scheduled_hashes
+            )
+            self.scheduled_hashes |= unconfirmed_transfer_hashes
+            confirmation_tasks = [
+                self.transfer_events[transfer_hash]
+                for transfer_hash in unconfirmed_transfer_hashes
+            ]
+        else:
+            confirmation_tasks = []
 
         self.clear_transfers()
         return confirmation_tasks

--- a/tools/bridge/bridge/transfer_recorder.py
+++ b/tools/bridge/bridge/transfer_recorder.py
@@ -12,7 +12,7 @@ from bridge.utils import compute_transfer_hash
 
 
 class TransferRecorder:
-    def __init__(self, is_validating: bool = True) -> None:
+    def __init__(self) -> None:
         self.transfer_events: Dict[Hash32, AttributeDict] = {}
 
         self.transfer_hashes: Set[Hash32] = set()
@@ -23,7 +23,7 @@ class TransferRecorder:
 
         self.home_chain_synced_until = 0.0
 
-        self.is_validating = is_validating
+        self.is_validating = False
 
     def start_validating(self) -> None:
         if self.is_validating:

--- a/tools/bridge/bridge/validator_status_watcher.py
+++ b/tools/bridge/bridge/validator_status_watcher.py
@@ -1,13 +1,20 @@
 import logging
+from typing import Optional
 
 import gevent
-from eth_utils import is_canonical_address
-from gevent.event import Event
+from eth_utils import is_canonical_address, to_checksum_address
+
+logger = logging.getLogger(__name__)
 
 
 class ValidatorStatusWatcher:
     def __init__(
-        self, validator_proxy_contract, validator_address, poll_interval
+        self,
+        validator_proxy_contract,
+        validator_address,
+        poll_interval,
+        start_validating_callback,
+        stop_validating_callback,
     ) -> None:
         self.validator_proxy_contract = validator_proxy_contract
         if not is_canonical_address(validator_address):
@@ -15,32 +22,42 @@ class ValidatorStatusWatcher:
         self.validator_address = validator_address
 
         self.poll_interval = poll_interval
+        self.start_validating_callback = start_validating_callback
+        self.stop_validating_callback = stop_validating_callback
 
-        self.has_started_validating = Event()
-        self.has_stopped_validating = Event()
+        self.is_validating: Optional[bool] = None
 
         self.logger = logging.getLogger(
             "bridge.validation_status_watcher.ValidationStatusWatcher"
         )
 
     def run(self) -> None:
+        self.is_validating = self.check_validator_status()
+        if self.is_validating:
+            self.logger.info("The account is a member of the validator set")
+            self.start_validating_callback()
+        else:
+            self.logger.warning(
+                f"The account with address {to_checksum_address(self.validator_address)} is not a "
+                f"member of the validator set at the moment. This status will be checked "
+                f"periodically."
+            )
+
         while True:
-            is_validator = self.check_validator_status()
-
-            if is_validator and not self.has_started_validating.is_set():
-                self.has_started_validating.set()
-                self.logger.info("Starting to validate")
-
-            if not is_validator and self.has_started_validating.is_set():
-                self.has_stopped_validating.set()
-                self.logger.info(
-                    "Stopping to validate as we dropped out of the validator set"
-                )
-                break
-
             gevent.sleep(self.poll_interval)
 
+            has_been_validating_before = self.is_validating
+            self.is_validating = self.check_validator_status()
+
+            if self.is_validating and not has_been_validating_before:
+                logger.info("Account joined the validator set")
+                self.start_validating_callback()
+            elif not self.is_validating and has_been_validating_before:
+                logger.info("Account has left the validator set")
+                self.stop_validating_callback()
+
     def check_validator_status(self):
+        self.logger.debug("Checking validator status")
         return self.validator_proxy_contract.functions.isValidator(
             self.validator_address
         ).call()

--- a/tools/bridge/bridge/validator_status_watcher.py
+++ b/tools/bridge/bridge/validator_status_watcher.py
@@ -1,0 +1,46 @@
+import logging
+
+import gevent
+from eth_utils import is_canonical_address
+from gevent.event import Event
+
+
+class ValidatorStatusWatcher:
+    def __init__(
+        self, validator_proxy_contract, validator_address, poll_interval
+    ) -> None:
+        self.validator_proxy_contract = validator_proxy_contract
+        if not is_canonical_address(validator_address):
+            raise ValueError("Validator address must be given in canonical format")
+        self.validator_address = validator_address
+
+        self.poll_interval = poll_interval
+
+        self.has_started_validating = Event()
+        self.has_stopped_validating = Event()
+
+        self.logger = logging.getLogger(
+            "bridge.validation_status_watcher.ValidationStatusWatcher"
+        )
+
+    def run(self) -> None:
+        while True:
+            is_validator = self.check_validator_status()
+
+            if is_validator and not self.has_started_validating.is_set():
+                self.has_started_validating.set()
+                self.logger.info("Starting to validate")
+
+            if not is_validator and self.has_started_validating.is_set():
+                self.has_stopped_validating.set()
+                self.logger.info(
+                    "Stopping to validate as we dropped out of the validator set"
+                )
+                break
+
+            gevent.sleep(self.poll_interval)
+
+    def check_validator_status(self):
+        return self.validator_proxy_contract.functions.isValidator(
+            self.validator_address
+        ).call()

--- a/tools/bridge/tests/test_confirmation_task_planner.py
+++ b/tools/bridge/tests/test_confirmation_task_planner.py
@@ -97,7 +97,9 @@ def completion_event(completion_events):
 @pytest.fixture
 def recorder():
     """A transfer recorder."""
-    return TransferRecorder(is_validating=True)
+    recorder = TransferRecorder()
+    recorder.start_validating()
+    return recorder
 
 
 def test_recorder_plans_transfers(recorder, transfer_event):
@@ -136,7 +138,7 @@ def test_recorder_does_not_plan_completed_transfer(recorder, transfer_hash, hash
 
 
 def test_transfer_recorder_does_not_plan_before_becoming_validator(transfer_event):
-    recorder = TransferRecorder(is_validating=False)
+    recorder = TransferRecorder()
     recorder.apply_proper_event(transfer_event)
     assert len(recorder.pull_transfers_to_confirm()) == 0
     recorder.start_validating()
@@ -152,7 +154,7 @@ def test_transfer_recorder_drops_completed_transfers_before_becoming_validator(h
         COMPLETION_EVENT_NAME, compute_transfer_hash(transfer_event), next(hashes)
     )
 
-    recorder = TransferRecorder(is_validating=False)
+    recorder = TransferRecorder()
     recorder.apply_proper_event(transfer_event)
     recorder.apply_proper_event(completion_event)
     recorder.start_validating()

--- a/tools/bridge/tests/test_validator_status_watcher.py
+++ b/tools/bridge/tests/test_validator_status_watcher.py
@@ -1,0 +1,75 @@
+import gevent
+
+from bridge.validator_status_watcher import ValidatorStatusWatcher
+
+
+def test_watcher_checks_status_correctly_for_validator(
+    validator_proxy_with_validators, validator_address, spawn
+):
+    validator_status_watcher = ValidatorStatusWatcher(
+        validator_proxy_with_validators, validator_address, poll_interval=1
+    )
+    assert validator_status_watcher.check_validator_status()
+    assert not validator_status_watcher.has_started_validating.is_set()
+    assert not validator_status_watcher.has_stopped_validating.is_set()
+
+    spawn(validator_status_watcher.run)
+    with gevent.timeout(0.01):
+        validator_status_watcher.has_started_validating.wait()
+    assert not validator_status_watcher.has_stopped_validating.is_set()
+
+
+def test_watcher_checks_status_correctly_for_non_validator(
+    validator_proxy_with_validators, non_validator_address, spawn
+):
+    validator_status_watcher = ValidatorStatusWatcher(
+        validator_proxy_with_validators, non_validator_address, poll_interval=1
+    )
+    assert not validator_status_watcher.check_validator_status()
+    assert not validator_status_watcher.has_started_validating.is_set()
+    assert not validator_status_watcher.has_stopped_validating.is_set()
+
+    spawn(validator_status_watcher.run)
+    gevent.sleep(0.01)
+    assert not validator_status_watcher.has_started_validating.is_set()
+    assert not validator_status_watcher.has_stopped_validating.is_set()
+
+
+def test_watcher_notices_validator_set_joining(
+    validator_proxy_contract, non_validator_address, system_address, spawn
+):
+    poll_interval = 0.1
+    validator_status_watcher = ValidatorStatusWatcher(
+        validator_proxy_contract, non_validator_address, poll_interval=poll_interval
+    )
+
+    spawn(validator_status_watcher.run)
+
+    validator_proxy_contract.functions.updateValidators(
+        [non_validator_address]
+    ).transact({"from": system_address})
+
+    with gevent.timeout(2 * poll_interval):
+        validator_status_watcher.has_started_validating.wait()
+    assert not validator_status_watcher.has_stopped_validating.is_set()
+
+
+def test_watcher_notices_validator_set_leaving(
+    validator_proxy_with_validators, validator_address, system_address, spawn
+):
+    poll_interval = 0.1
+    validator_status_watcher = ValidatorStatusWatcher(
+        validator_proxy_with_validators, validator_address, poll_interval=poll_interval
+    )
+
+    spawn(validator_status_watcher.run)
+    with gevent.timeout(0.01):
+        validator_status_watcher.has_started_validating.wait()
+
+    validator_proxy_with_validators.functions.updateValidators([]).transact(
+        {"from": system_address}
+    )
+
+    with gevent.timeout(2 * poll_interval):
+        validator_status_watcher.has_stopped_validating.wait()
+    assert not validator_status_watcher.has_started_validating.is_set()

--- a/tools/bridge/tests/test_validator_status_watcher.py
+++ b/tools/bridge/tests/test_validator_status_watcher.py
@@ -1,75 +1,110 @@
+from unittest.mock import Mock
+
 import gevent
+from eth_utils import to_canonical_address
 
 from bridge.validator_status_watcher import ValidatorStatusWatcher
 
 
-def test_watcher_checks_status_correctly_for_validator(
+def test_watcher_checks_initial_validator_status_correctly(
     validator_proxy_with_validators, validator_address, spawn
 ):
+    start_callback = Mock()
+    stop_callback = Mock()
     validator_status_watcher = ValidatorStatusWatcher(
-        validator_proxy_with_validators, validator_address, poll_interval=1
+        validator_proxy_with_validators,
+        to_canonical_address(validator_address),
+        poll_interval=1,
+        start_validating_callback=start_callback,
+        stop_validating_callback=stop_callback,
     )
-    assert validator_status_watcher.check_validator_status()
-    assert not validator_status_watcher.has_started_validating.is_set()
-    assert not validator_status_watcher.has_stopped_validating.is_set()
-
-    spawn(validator_status_watcher.run)
-    with gevent.timeout(0.01):
-        validator_status_watcher.has_started_validating.wait()
-    assert not validator_status_watcher.has_stopped_validating.is_set()
-
-
-def test_watcher_checks_status_correctly_for_non_validator(
-    validator_proxy_with_validators, non_validator_address, spawn
-):
-    validator_status_watcher = ValidatorStatusWatcher(
-        validator_proxy_with_validators, non_validator_address, poll_interval=1
-    )
-    assert not validator_status_watcher.check_validator_status()
-    assert not validator_status_watcher.has_started_validating.is_set()
-    assert not validator_status_watcher.has_stopped_validating.is_set()
 
     spawn(validator_status_watcher.run)
     gevent.sleep(0.01)
-    assert not validator_status_watcher.has_started_validating.is_set()
-    assert not validator_status_watcher.has_stopped_validating.is_set()
+    assert validator_status_watcher.is_validating
+    start_callback.assert_called_once()
+    stop_callback.assert_not_called()
+
+
+def test_watcher_checks_initial_non_validator_status_correctly(
+    validator_proxy_with_validators, non_validator_address, spawn
+):
+    start_callback = Mock()
+    stop_callback = Mock()
+    validator_status_watcher = ValidatorStatusWatcher(
+        validator_proxy_with_validators,
+        to_canonical_address(non_validator_address),
+        poll_interval=1,
+        start_validating_callback=start_callback,
+        stop_validating_callback=stop_callback,
+    )
+
+    spawn(validator_status_watcher.run)
+    gevent.sleep(0.01)
+    assert not validator_status_watcher.is_validating
+    start_callback.assert_not_called()
+    stop_callback.assert_not_called()
 
 
 def test_watcher_notices_validator_set_joining(
     validator_proxy_contract, non_validator_address, system_address, spawn
 ):
+    start_callback = Mock()
+    stop_callback = Mock()
     poll_interval = 0.1
     validator_status_watcher = ValidatorStatusWatcher(
-        validator_proxy_contract, non_validator_address, poll_interval=poll_interval
+        validator_proxy_contract,
+        to_canonical_address(non_validator_address),
+        poll_interval=poll_interval,
+        start_validating_callback=start_callback,
+        stop_validating_callback=stop_callback,
     )
 
     spawn(validator_status_watcher.run)
+    gevent.sleep(0.01)  # check initial status
+    assert not validator_status_watcher.is_validating
+    start_callback.assert_not_called()
+    stop_callback.assert_not_called()
 
+    # join validator set
     validator_proxy_contract.functions.updateValidators(
         [non_validator_address]
     ).transact({"from": system_address})
 
-    with gevent.timeout(2 * poll_interval):
-        validator_status_watcher.has_started_validating.wait()
-    assert not validator_status_watcher.has_stopped_validating.is_set()
+    gevent.sleep(poll_interval * 1.5)  # check a second time
+    assert validator_status_watcher.is_validating
+    start_callback.assert_called_once()
+    stop_callback.assert_not_called()
 
 
 def test_watcher_notices_validator_set_leaving(
     validator_proxy_with_validators, validator_address, system_address, spawn
 ):
+    start_callback = Mock()
+    stop_callback = Mock()
     poll_interval = 0.1
     validator_status_watcher = ValidatorStatusWatcher(
-        validator_proxy_with_validators, validator_address, poll_interval=poll_interval
+        validator_proxy_with_validators,
+        to_canonical_address(validator_address),
+        poll_interval=poll_interval,
+        start_validating_callback=start_callback,
+        stop_validating_callback=stop_callback,
     )
 
     spawn(validator_status_watcher.run)
-    with gevent.timeout(0.01):
-        validator_status_watcher.has_started_validating.wait()
+    gevent.sleep(poll_interval * 0.01)  # check initial status
+    assert validator_status_watcher.is_validating
+    start_callback.assert_called_once()
+    stop_callback.assert_not_called()
 
+    start_callback.reset_mock()
+
+    # leave validator set
     validator_proxy_with_validators.functions.updateValidators([]).transact(
         {"from": system_address}
     )
 
-    with gevent.timeout(2 * poll_interval):
-        validator_status_watcher.has_stopped_validating.wait()
-    assert not validator_status_watcher.has_started_validating.is_set()
+    gevent.sleep(poll_interval)  # check a second time
+    assert not validator_status_watcher.is_validating
+    start_callback.assert_not_called()
+    stop_callback.assert_called_once()


### PR DESCRIPTION
Opening PR to see CI output as tests don't run locally on my machine anymore (due to missing solidity version) and to give others a chance to adopt this PR as I'm not gonna work today.

The way I quit when we exit the validator set looks a bit weird to me, but I didn't come up with something better. Would have been much nicer with Trio!

I also don't like how the `is_validating` status is passed through the confirmation task planner to the transfer recorder. But I don't see a way to avoid this.

Closes #276 and #306