### PR TITLE
Misc production fixes

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -10,7 +10,7 @@ certifi==2019.6.16
 cfgv==2.0.1
 chardet==3.0.4
 Click==7.0
-contract-deploy-tools==0.4.4
+contract-deploy-tools==0.5.0
 cryptography==2.7
 cytoolz==0.10.0
 decorator==4.4.0

--- a/contracts/contracts/token/FakeNetworkToken.sol
+++ b/contracts/contracts/token/FakeNetworkToken.sol
@@ -1,0 +1,29 @@
+/*
+This contract is only used for testing. It emits Transfer events just
+like the TrustlinesNetworkToken contract.
+
+It can be deployed with the following command
+
+    deploy-tools deploy FakeNetworkToken
+
+Please note that all of the functions are public.
+*/
+
+pragma solidity ^0.5.8;
+
+contract FakeNetworkToken {
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    function transfer(address from, address to, uint256 value) public {
+        emit Transfer(from, to, value);
+    }
+
+    /* emit multiple events in a single transaction */
+    function transfer4(address from, address to, uint256 value) public {
+        emit Transfer(from, to, value);
+        emit Transfer(from, to, value);
+
+        emit Transfer(from, to, value + 1);
+        emit Transfer(from, to, value + 2);
+    }
+}

--- a/tools/bridge/README.md
+++ b/tools/bridge/README.md
@@ -121,10 +121,17 @@ Logging can be configured globally or for specific components by setting the
 
 ```toml
 [logging.root]
-level = "INFO"
+level = "DEBUG"
 
 [logging.loggers."bridge.main"]
 level = "DEBUG"
+
+# web3 is too verbose with level debug
+[logging.loggers.web3]
+level = "INFO"
+
+[logging.loggers.urllib3]
+level = "INFO"
 ```
 
 Internally this is using _Python_'s

--- a/tools/bridge/bridge/confirmation_sender.py
+++ b/tools/bridge/bridge/confirmation_sender.py
@@ -138,9 +138,14 @@ class ConfirmationSender:
                 continue
 
             if receipt and receipt.blockNumber <= confirmation_threshold:
-                self.logger.info(
-                    f"Transaction has been confirmed: {oldest_pending_transaction.hash.hex()}"
-                )
+                if receipt.status == 0:
+                    self.logger.warning(
+                        f"Transaction failed: {oldest_pending_transaction.hash.hex()}"
+                    )
+                else:
+                    self.logger.info(
+                        f"Transaction has been confirmed: {oldest_pending_transaction.hash.hex()}"
+                    )
                 confirmed_transaction = (
                     self.pending_transaction_queue.get()
                 )  # remove from queue

--- a/tools/bridge/bridge/contract_abis.py
+++ b/tools/bridge/bridge/contract_abis.py
@@ -64,7 +64,7 @@ HOME_BRIDGE_ABI = [
             {"indexed": False, "name": "transactionHash", "type": "bytes32"},
             {"indexed": False, "name": "amount", "type": "uint256"},
             {"indexed": False, "name": "recipient", "type": "address"},
-            {"indexed": False, "name": "validator", "type": "address"},
+            {"indexed": True, "name": "validator", "type": "address"},
         ],
         "name": "Confirmation",
         "type": "event",

--- a/tools/bridge/bridge/event_fetcher.py
+++ b/tools/bridge/bridge/event_fetcher.py
@@ -2,7 +2,7 @@ import logging
 from time import sleep, time
 from typing import Any, Dict, List
 
-from eth_utils import is_same_address, to_checksum_address
+from eth_utils import to_checksum_address
 from web3 import Web3
 from web3.contract import Contract
 from web3.datastructures import AttributeDict
@@ -71,15 +71,6 @@ class EventFetcher:
                 toBlock=to_block_number,
                 argument_filters=argument_filters,
             )
-            # hack until validator event argument is indexed
-            if "validator" in argument_filters:
-                fetched_events = [
-                    event
-                    for event in fetched_events
-                    if is_same_address(
-                        event.args.validator, argument_filters["validator"]
-                    )
-                ]
             events += fetched_events
 
             if len(fetched_events) > 0:

--- a/tools/bridge/bridge/event_fetcher.py
+++ b/tools/bridge/bridge/event_fetcher.py
@@ -2,7 +2,6 @@ import logging
 from time import sleep, time
 from typing import Any, Dict, List
 
-from eth_utils import to_checksum_address
 from web3 import Web3
 from web3.contract import Contract
 from web3.datastructures import AttributeDict
@@ -24,6 +23,7 @@ class EventFetcher:
         event_queue: Any,
         max_reorg_depth: int,
         start_block_number: int,
+        name: str = "",
     ):
         if event_fetch_limit <= 0:
             raise ValueError("Can not fetch events with zero or negative limit!")
@@ -35,10 +35,11 @@ class EventFetcher:
             raise ValueError(
                 "Can not fetch events starting from a negative block number!"
             )
-
-        self.logger = logging.getLogger(
-            f"bridge.event_fetcher.{to_checksum_address(contract.address)}"
-        )
+        self.name = name
+        if name:
+            self.logger = logging.getLogger(f"{__name__}.{name}")
+        else:
+            self.logger = logging.getLogger(f"{__name__}")
 
         self.web3 = web3
         self.contract = contract

--- a/tools/bridge/bridge/main.py
+++ b/tools/bridge/bridge/main.py
@@ -168,7 +168,13 @@ def main(config_path: str) -> None:
         raise click.UsageError(f"Invalid config file: {value_error}") from value_error
 
     configure_logging(config)
-    logger.info("Starting Trustlines Bridge Validation Server")
+    validator_address = PrivateKey(
+        config["validator_private_key"]
+    ).public_key.to_checksum_address()
+
+    logger.info(
+        f"Starting Trustlines Bridge Validation Server for address {validator_address}"
+    )
 
     transfer_event_queue = Queue()
     home_bridge_event_queue = Queue()

--- a/tools/bridge/bridge/main.py
+++ b/tools/bridge/bridge/main.py
@@ -98,6 +98,7 @@ def make_transfer_event_fetcher(config, transfer_event_queue):
         event_queue=transfer_event_queue,
         max_reorg_depth=config["foreign_chain_max_reorg_depth"],
         start_block_number=config["foreign_chain_event_fetch_start_block_number"],
+        name="foreign",
     )
 
 
@@ -122,6 +123,7 @@ def make_home_bridge_event_fetcher(config, home_bridge_event_queue):
         event_queue=home_bridge_event_queue,
         max_reorg_depth=config["home_chain_max_reorg_depth"],
         start_block_number=config["home_chain_event_fetch_start_block_number"],
+        name="home",
     )
 
 


### PR DESCRIPTION
- Enhance the logging output
- Do not use the eth addresses as part of the loggers name
- Update contract-deploy-tools to 0.5.0
- Log the bridge validators address when starting
- Show how to silence web3 with the log configuration
- Add FakeNetworkToken contract
- Rely on web3 filtering and remove the validator filtering hack
- Fix HOME_BRIDGE_ABI: Confirmation.validator is indexed now
- Log transaction failures in the confirmation sender
