### PR TITLE
Remove dotenv

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -65,7 +65,6 @@ pyparsing==2.4.2
 pysha3==1.0.2
 pytest==5.0.1
 python-dateutil==2.8.0
-python-dotenv==0.10.3
 pytzdata==2019.2
 PyYAML==5.1.2
 requests==2.22.0

--- a/tools/bridge/README.md
+++ b/tools/bridge/README.md
@@ -92,6 +92,12 @@ are equal to the ones in the TOML file but in upper case (e.g. `HOME_RPC_URL`).
 The `--config` (`-c`) CLI parameter allows to define the path to the
 configuration file.
 
+There are tools which make working with a set of environment variables a more pleasent experience.
+One of those is [dotenv](https://www.npmjs.com/package/dotenv-cli) which allows loading environment
+variables from a `.env` file, an example of which is provided [here](.env.example). To start the
+bridge with configuration from a `.env` file, run `dotenv tlbc-bridge`. Alternatively, you can
+also use [envdir](https://pypi.org/project/envdir/).
+
 The following table lists all available options. Configuration entries
 with a default value are optional.
 

--- a/tools/bridge/bridge/config.py
+++ b/tools/bridge/bridge/config.py
@@ -3,7 +3,6 @@ from typing import Any, Dict
 
 import toml
 import validators
-from dotenv import load_dotenv
 from eth_keys.constants import SECPK1_N
 from eth_utils import (
     big_endian_to_int,
@@ -14,8 +13,6 @@ from eth_utils import (
     to_canonical_address,
 )
 from eth_utils.toolz import merge
-
-load_dotenv()
 
 
 def validate_rpc_url(url: Any) -> str:

--- a/tools/bridge/bridge/main.py
+++ b/tools/bridge/bridge/main.py
@@ -198,10 +198,10 @@ def stop(pool, timeout):
 def main(config_path: str) -> None:
     """The Trustlines Bridge Validation Server
 
-    Configuration can be made using a TOML file or via Environment Variables.
-    A dotenv (.env) file will be automatically evaluated.
+    Configuration can be made using a TOML file or via environment variables. Tools such as dotenv
+    or envdir may simplify setting environment variables. For a dotenv example, see `.env.example`.
 
-    See .env.example and config.py for valid configuration options and defaults.
+    See config.py for valid configuration options and defaults.
     """
 
     try:

--- a/tools/bridge/requirements.txt
+++ b/tools/bridge/requirements.txt
@@ -4,7 +4,6 @@ eth-utils
 gevent
 toml
 web3
-python-dotenv
 validators
 
 # --- development dependencies:

--- a/tools/bridge/setup.cfg
+++ b/tools/bridge/setup.cfg
@@ -11,7 +11,6 @@ install_requires =
     gevent>=1.4,<1.5
     toml>=0.10,<0.11
     web3>=5.0,<5.1
-    python-dotenv>=0.10.3,<0.11
     validators>=0.13,<0.14
 packages = bridge
 


### PR DESCRIPTION
Closes #323 

Also transformed `.env.example` to an `example_envdir`, but did not add `envdir` as a dependency, because I guess it's best to leave it to the validator what tool they want to use.