### PR TITLE
Use tenacity to retry event_fetcher's web3 calls

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -74,6 +74,7 @@ semantic-version==2.6.0
 setuptools==41.0.1
 setuptools-scm==3.3.3
 six==1.12.0
+tenacity==5.1.1
 toml==0.10.0
 toolz==0.10.0
 trie==1.4.0

--- a/tools/bridge/bridge/event_fetcher.py
+++ b/tools/bridge/bridge/event_fetcher.py
@@ -2,6 +2,7 @@ import logging
 from time import sleep, time
 from typing import Any, Dict, List
 
+import tenacity
 from web3 import Web3
 from web3.contract import Contract
 from web3.datastructures import AttributeDict
@@ -49,13 +50,38 @@ class EventFetcher:
         self.max_reorg_depth = max_reorg_depth
         self.last_fetched_block_number = start_block_number - 1
 
+        # We can't use the tenacity decorator because we're using an
+        # instance local logger So, we instantiate the Retrying object
+        # here and use it explicitly.
+        self._retrying = tenacity.Retrying(
+            wait=tenacity.wait_exponential(multiplier=1, min=5, max=120),
+            before_sleep=tenacity.before_sleep_log(self.logger, logging.WARN),
+        )
+
+    def _rpc_latest_block(self):
+        return self._retrying.call(lambda: self.web3.eth.blockNumber)
+
+    def _rpc_get_logs(
+        self,
+        event_name: str,
+        from_block_number: int,
+        to_block_number: int,
+        argument_filters,
+    ):
+        return self._retrying.call(
+            self.contract.events[event_name].getLogs,
+            fromBlock=from_block_number,
+            toBlock=to_block_number,
+            argument_filters=argument_filters,
+        )
+
     def fetch_events_in_range(
         self, from_block_number: int, to_block_number: int
     ) -> List:
         if from_block_number < 0:
             raise ValueError("Can not fetch events from a negative block number!")
 
-        if to_block_number > self.web3.eth.blockNumber:
+        if to_block_number > self._rpc_latest_block():
             raise ValueError("Can not fetch events for blocks past the current head!")
 
         if from_block_number > to_block_number:
@@ -67,9 +93,10 @@ class EventFetcher:
 
         events: List[AttributeDict] = []
         for event_name, argument_filters in self.filter_definition.items():
-            fetched_events = self.contract.events[event_name].getLogs(
-                fromBlock=from_block_number,
-                toBlock=to_block_number,
+            fetched_events = self._rpc_get_logs(
+                event_name=event_name,
+                from_block_number=from_block_number,
+                to_block_number=to_block_number,
                 argument_filters=argument_filters,
             )
             events += fetched_events
@@ -101,7 +128,7 @@ class EventFetcher:
         """
         while True:
             from_block_number = self.last_fetched_block_number + 1
-            reorg_safe_block_number = self.web3.eth.blockNumber - self.max_reorg_depth
+            reorg_safe_block_number = self._rpc_latest_block() - self.max_reorg_depth
             to_block_number = min(
                 from_block_number + self.event_fetch_limit - 1, reorg_safe_block_number
             )

--- a/tools/bridge/requirements.txt
+++ b/tools/bridge/requirements.txt
@@ -6,6 +6,7 @@ toml
 web3
 python-dotenv
 validators
+tenacity
 
 # --- development dependencies:
 

--- a/tools/bridge/setup.cfg
+++ b/tools/bridge/setup.cfg
@@ -13,6 +13,7 @@ install_requires =
     web3>=5.0,<5.1
     python-dotenv>=0.10.3,<0.11
     validators>=0.13,<0.14
+    tenacity>=5.1.1,<5.2
 packages = bridge
 
 [options.entry_points]


### PR DESCRIPTION
We retry and log warnings forever at the moment. This most probably
will need some tuning.

For documentation on tenacity please visit
https://tenacity.readthedocs.io/en/latest/

See https://github.com/trustlines-protocol/blockchain/issues/320