### PR TITLE
Implement validator balance watcher

### DIFF
--- a/tools/bridge/bridge/config.py
+++ b/tools/bridge/bridge/config.py
@@ -12,6 +12,7 @@ from eth_utils import (
     is_checksum_address,
     is_hex,
     to_canonical_address,
+    to_wei,
 )
 from eth_utils.toolz import merge
 
@@ -98,6 +99,8 @@ OPTIONAL_CONFIG_ENTRIES_WITH_DEFAULTS: Dict[str, Any] = {
     "foreign_chain_max_reorg_depth": 10,
     "foreign_chain_event_poll_interval": 5,
     "foreign_chain_event_fetch_start_block_number": 0,
+    "balance_warn_threshold": to_wei(0.1, "ether"),
+    "balance_warn_poll_interval": 60,
 }
 
 CONFIG_ENTRY_VALIDATORS = {
@@ -117,6 +120,8 @@ CONFIG_ENTRY_VALIDATORS = {
     "foreign_bridge_contract_address": validate_checksum_address,
     "foreign_chain_event_fetch_start_block_number": validate_non_negative_integer,
     "validator_private_key": validate_private_key,
+    "balance_warn_threshold": validate_non_negative_integer,
+    "balance_warn_poll_interval": validate_positive_float,
 }
 
 assert all(key in CONFIG_ENTRY_VALIDATORS for key in REQUIRED_CONFIG_ENTRIES)

--- a/tools/bridge/bridge/config.py
+++ b/tools/bridge/bridge/config.py
@@ -99,7 +99,9 @@ OPTIONAL_CONFIG_ENTRIES_WITH_DEFAULTS: Dict[str, Any] = {
     "foreign_chain_max_reorg_depth": 10,
     "foreign_chain_event_poll_interval": 5,
     "foreign_chain_event_fetch_start_block_number": 0,
-    "balance_warn_threshold": to_wei(0.1, "ether"),
+    # disable type check as type hint in eth_utils is wrong, (see
+    # https://github.com/ethereum/eth-utils/issues/168)
+    "balance_warn_threshold": to_wei(0.1, "ether"),  # type: ignore
     "balance_warn_poll_interval": 60,
 }
 

--- a/tools/bridge/bridge/validator_balance_watcher.py
+++ b/tools/bridge/bridge/validator_balance_watcher.py
@@ -1,0 +1,27 @@
+import logging
+
+import gevent
+from eth_utils import from_wei
+
+logger = logging.getLogger(__name__)
+
+
+class ValidatorBalanceWatcher:
+    def __init__(
+        self, w3, validator_address, poll_interval, balance_warn_threshold
+    ) -> None:
+        self.w3 = w3
+        self.validator_address = validator_address
+        self.poll_interval = poll_interval
+        self.balance_warn_threshold = balance_warn_threshold
+
+    def run(self) -> None:
+        while True:
+            current_balance = self.w3.eth.getBalance(self.validator_address)
+            if current_balance < self.balance_warn_threshold:
+                logger.warn(
+                    f"Low balance of validator account: {from_wei(current_balance, 'ether')} "
+                    f"TLC"
+                )
+
+            gevent.sleep(self.poll_interval)


### PR DESCRIPTION
Closes #328 

- regularly check balance of validator account and emit a warning if it gets too low
- also check the balance at launch and refuse to start if it is too low

I did not go with the solution suggested in #328 as we would only learn that something is wrong when we become a validator. If we'd start the node early we'd likely miss it.

I did not write tests for the watcher as all it does is print log messages which I wouldn't know how to test for in a nice way. I did not write tests for the initial check as we don't have tests for the main function in general, running it against `eth_tester` is not possible, and deploying a new chain for this is overkill.