### PR TITLE
Clear history after transfer and completion event

### DIFF
--- a/tools/bridge/bridge/transfer_recorder.py
+++ b/tools/bridge/bridge/transfer_recorder.py
@@ -50,13 +50,7 @@ class TransferRecorder:
             raise ValueError(f"Got unknown event {event}")
 
     def clear_transfers(self) -> None:
-        if self.is_validating:
-            transfer_hashes_to_remove = (
-                self.transfer_hashes & self.confirmation_hashes & self.completion_hashes
-            )
-        else:
-            # if we're not validating, there's no chance to see a confirmation by us
-            transfer_hashes_to_remove = self.transfer_hashes & self.completion_hashes
+        transfer_hashes_to_remove = self.transfer_hashes & self.completion_hashes
 
         self.transfer_hashes -= transfer_hashes_to_remove
         self.confirmation_hashes -= transfer_hashes_to_remove


### PR DESCRIPTION
We want to delete a transfer hash when we're sure all corresponding events have been observed. To do this, we only have to wait for the transfer and completion event, as the confirmation event will never appear after the completion event. It is not guaranteed that the confirmation event is observed after the transfer event as they come from two different chains and two different queues.