### PR TITLE
Confirmation sender improvements

### DIFF
--- a/tools/bridge/bridge/confirmation_sender.py
+++ b/tools/bridge/bridge/confirmation_sender.py
@@ -93,14 +93,12 @@ class Sender:
         while True:
             transfer_event = self.transfer_event_queue.get()
             assert isinstance(transfer_event, AttributeDict)
-
-            transaction = self.prepare_confirmation_transaction(transfer_event)
+            nonce = self.get_next_nonce()
+            transaction = self.prepare_confirmation_transaction(transfer_event, nonce)
             assert transaction is not None
             self.send_confirmation_transaction(transaction)
 
-    def prepare_confirmation_transaction(self, transfer_event):
-        nonce = self.get_next_nonce()
-
+    def prepare_confirmation_transaction(self, transfer_event, nonce: int):
         transfer_hash = compute_transfer_hash(transfer_event)
         transaction_hash = transfer_event.transactionHash
         amount = transfer_event.args.value

--- a/tools/bridge/bridge/confirmation_sender.py
+++ b/tools/bridge/bridge/confirmation_sender.py
@@ -75,7 +75,7 @@ class Sender:
 
         if not is_bridge_validator(home_bridge_contract, self.address):
             logger.warning(
-                f"The address {self.address} is not a bridge validator to confirm "
+                f"The address {to_checksum_address(self.address)} is not a bridge validator to confirm "
                 f"transfers on the home bridge contract!"
             )
 
@@ -93,13 +93,6 @@ class Sender:
         while True:
             transfer_event = self.transfer_event_queue.get()
             assert isinstance(transfer_event, AttributeDict)
-
-            if not is_bridge_validator(self.home_bridge_contract, self.address):
-                logger.warning(
-                    f"Can not confirm transaction because {to_checksum_address(self.address)}"
-                    f"is not a bridge validator!"
-                )
-                continue
 
             transaction = self.prepare_confirmation_transaction(transfer_event)
 

--- a/tools/bridge/bridge/confirmation_sender.py
+++ b/tools/bridge/bridge/confirmation_sender.py
@@ -95,9 +95,8 @@ class Sender:
             assert isinstance(transfer_event, AttributeDict)
 
             transaction = self.prepare_confirmation_transaction(transfer_event)
-
-            if transaction is not None:
-                self.send_confirmation_transaction(transaction)
+            assert transaction is not None
+            self.send_confirmation_transaction(transaction)
 
     def prepare_confirmation_transaction(self, transfer_event):
         nonce = self.get_next_nonce()

--- a/tools/bridge/tests/test_confirmation_sender.py
+++ b/tools/bridge/tests/test_confirmation_sender.py
@@ -188,27 +188,3 @@ def test_pending_transfers_are_cleared(
     tester_home.mine_blocks(max_reorg_depth - 1)
     gevent.sleep(1.5 * HOME_CHAIN_STEP_DURATION)
     assert confirmation_sender.pending_transaction_queue.qsize() == 0
-
-
-def test_do_not_confirm_as_non_bridge_validator(
-    confirmation_sender_with_non_validator_account,
-    transfer_queue,
-    transfer_event,
-    spawn,
-):
-    # TODO: This could fail in a non-testing environment. RPC requests can take
-    # longer or fail for any other reason. An empty queue at the end isn't
-    # a strong affirmation.
-
-    spawn(confirmation_sender_with_non_validator_account.run)
-
-    assert (
-        confirmation_sender_with_non_validator_account.pending_transaction_queue.empty()
-    )
-
-    transfer_queue.put(transfer_event)
-    gevent.sleep(0.1)
-
-    assert (
-        confirmation_sender_with_non_validator_account.pending_transaction_queue.empty()
-    )

--- a/tools/bridge/tests/test_confirmation_sender.py
+++ b/tools/bridge/tests/test_confirmation_sender.py
@@ -112,7 +112,7 @@ def test_transaction_preparation(
     transfer_event,
 ):
     signed_transaction = confirmation_sender.sender.prepare_confirmation_transaction(
-        transfer_event
+        transfer_event, nonce=1234
     )
     transaction = rlp.decode(
         bytes(signed_transaction.rawTransaction), SpuriousDragonTransaction
@@ -121,7 +121,7 @@ def test_transaction_preparation(
     assert transaction.to == decode_hex(home_bridge_contract.address)
     assert transaction.gas_price == gas_price
     assert transaction.value == 0
-    assert transaction.nonce == confirmation_sender.sender.get_next_nonce()
+    assert transaction.nonce == 1234
 
 
 def test_transaction_sending(
@@ -133,7 +133,7 @@ def test_transaction_sending(
     validator_address,
 ):
     transaction = confirmation_sender.sender.prepare_confirmation_transaction(
-        transfer_event
+        transfer_event, nonce=confirmation_sender.sender.get_next_nonce()
     )
     confirmation_sender.sender.send_confirmation_transaction(transaction)
     assert transaction == confirmation_sender.pending_transaction_queue.peek()


### PR DESCRIPTION
This contains some improvements for the confirmation sender's Watcher class. It retries web3 RPC calls and the queue handling has been simplified.

