### PR TITLE
Last safety net

### DIFF
--- a/tools/bridge/bridge/confirmation_sender.py
+++ b/tools/bridge/bridge/confirmation_sender.py
@@ -93,14 +93,12 @@ class Sender:
         while True:
             transfer_event = self.transfer_event_queue.get()
             assert isinstance(transfer_event, AttributeDict)
-
-            transaction = self.prepare_confirmation_transaction(transfer_event)
+            nonce = self.get_next_nonce()
+            transaction = self.prepare_confirmation_transaction(transfer_event, nonce)
             assert transaction is not None
             self.send_confirmation_transaction(transaction)
 
-    def prepare_confirmation_transaction(self, transfer_event):
-        nonce = self.get_next_nonce()
-
+    def prepare_confirmation_transaction(self, transfer_event, nonce: int):
         transfer_hash = compute_transfer_hash(transfer_event)
         transaction_hash = transfer_event.transactionHash
         amount = transfer_event.args.value

--- a/tools/bridge/bridge/confirmation_sender.py
+++ b/tools/bridge/bridge/confirmation_sender.py
@@ -75,7 +75,7 @@ class Sender:
 
         if not is_bridge_validator(home_bridge_contract, self.address):
             logger.warning(
-                f"The address {self.address} is not a bridge validator to confirm "
+                f"The address {to_checksum_address(self.address)} is not a bridge validator to confirm "
                 f"transfers on the home bridge contract!"
             )
 
@@ -93,13 +93,6 @@ class Sender:
         while True:
             transfer_event = self.transfer_event_queue.get()
             assert isinstance(transfer_event, AttributeDict)
-
-            if not is_bridge_validator(self.home_bridge_contract, self.address):
-                logger.warning(
-                    f"Can not confirm transaction because {to_checksum_address(self.address)}"
-                    f"is not a bridge validator!"
-                )
-                continue
 
             transaction = self.prepare_confirmation_transaction(transfer_event)
 

--- a/tools/bridge/bridge/confirmation_sender.py
+++ b/tools/bridge/bridge/confirmation_sender.py
@@ -95,9 +95,8 @@ class Sender:
             assert isinstance(transfer_event, AttributeDict)
 
             transaction = self.prepare_confirmation_transaction(transfer_event)
-
-            if transaction is not None:
-                self.send_confirmation_transaction(transaction)
+            assert transaction is not None
+            self.send_confirmation_transaction(transaction)
 
     def prepare_confirmation_transaction(self, transfer_event):
         nonce = self.get_next_nonce()

--- a/tools/bridge/bridge/main.py
+++ b/tools/bridge/bridge/main.py
@@ -18,7 +18,7 @@ from toml.decoder import TomlDecodeError
 from web3 import HTTPProvider, Web3
 
 from bridge.config import load_config
-from bridge.confirmation_sender import ConfirmationSender
+from bridge.confirmation_sender import ConfirmationSender, make_sanity_check_transfer
 from bridge.confirmation_task_planner import ConfirmationTaskPlanner
 from bridge.constants import (
     APPLICATION_CLEANUP_TIMEOUT,
@@ -163,6 +163,11 @@ def make_confirmation_sender(config, confirmation_task_queue):
         private_key=config["validator_private_key"],
         gas_price=config["home_chain_gas_price"],
         max_reorg_depth=config["home_chain_max_reorg_depth"],
+        sanity_check_transfer=make_sanity_check_transfer(
+            foreign_bridge_contract_address=to_checksum_address(
+                config["foreign_bridge_contract_address"]
+            )
+        ),
     )
 
 

--- a/tools/bridge/tests/test_confirmation_sender.py
+++ b/tools/bridge/tests/test_confirmation_sender.py
@@ -4,12 +4,12 @@ import gevent
 import pytest
 import rlp
 from eth.vm.forks.spurious_dragon.transactions import SpuriousDragonTransaction
-from eth_utils import decode_hex, keccak
+from eth_utils import decode_hex, keccak, to_checksum_address
 from gevent.queue import Queue
 from hexbytes import HexBytes
 from web3.datastructures import AttributeDict
 
-from bridge.confirmation_sender import ConfirmationSender
+from bridge.confirmation_sender import ConfirmationSender, make_sanity_check_transfer
 from bridge.constants import HOME_CHAIN_STEP_DURATION
 from bridge.utils import compute_transfer_hash
 
@@ -44,7 +44,12 @@ def gas_price():
 
 @pytest.fixture
 def confirmation_sender(
-    transfer_queue, home_bridge_contract, validator_key, max_reorg_depth, gas_price
+    transfer_queue,
+    home_bridge_contract,
+    validator_key,
+    max_reorg_depth,
+    gas_price,
+    foreign_bridge_contract,
 ):
     """A confirmation sender."""
     return ConfirmationSender(
@@ -53,12 +58,20 @@ def confirmation_sender(
         private_key=validator_key.to_bytes(),
         gas_price=gas_price,
         max_reorg_depth=max_reorg_depth,
+        sanity_check_transfer=make_sanity_check_transfer(
+            to_checksum_address(foreign_bridge_contract.address)
+        ),
     )
 
 
 @pytest.fixture
 def confirmation_sender_with_non_validator_account(
-    transfer_queue, home_bridge_contract, non_validator_key, max_reorg_depth, gas_price
+    transfer_queue,
+    home_bridge_contract,
+    non_validator_key,
+    max_reorg_depth,
+    gas_price,
+    foreign_bridge_contract,
 ):
     """A confirmation sender."""
     return ConfirmationSender(
@@ -67,6 +80,9 @@ def confirmation_sender_with_non_validator_account(
         private_key=non_validator_key.to_bytes(),
         gas_price=gas_price,
         max_reorg_depth=max_reorg_depth,
+        sanity_check_transfer=make_sanity_check_transfer(
+            to_checksum_address(foreign_bridge_contract.address)
+        ),
     )
 
 

--- a/tools/bridge/tests/test_confirmation_sender.py
+++ b/tools/bridge/tests/test_confirmation_sender.py
@@ -188,27 +188,3 @@ def test_pending_transfers_are_cleared(
     tester_home.mine_blocks(max_reorg_depth - 1)
     gevent.sleep(1.5 * HOME_CHAIN_STEP_DURATION)
     assert confirmation_sender.pending_transaction_queue.qsize() == 0
-
-
-def test_do_not_confirm_as_non_bridge_validator(
-    confirmation_sender_with_non_validator_account,
-    transfer_queue,
-    transfer_event,
-    spawn,
-):
-    # TODO: This could fail in a non-testing environment. RPC requests can take
-    # longer or fail for any other reason. An empty queue at the end isn't
-    # a strong affirmation.
-
-    spawn(confirmation_sender_with_non_validator_account.run)
-
-    assert (
-        confirmation_sender_with_non_validator_account.pending_transaction_queue.empty()
-    )
-
-    transfer_queue.put(transfer_event)
-    gevent.sleep(0.1)
-
-    assert (
-        confirmation_sender_with_non_validator_account.pending_transaction_queue.empty()
-    )

--- a/tools/bridge/tests/test_confirmation_sender.py
+++ b/tools/bridge/tests/test_confirmation_sender.py
@@ -112,7 +112,7 @@ def test_transaction_preparation(
     transfer_event,
 ):
     signed_transaction = confirmation_sender.sender.prepare_confirmation_transaction(
-        transfer_event
+        transfer_event, nonce=1234
     )
     transaction = rlp.decode(
         bytes(signed_transaction.rawTransaction), SpuriousDragonTransaction
@@ -121,7 +121,7 @@ def test_transaction_preparation(
     assert transaction.to == decode_hex(home_bridge_contract.address)
     assert transaction.gas_price == gas_price
     assert transaction.value == 0
-    assert transaction.nonce == confirmation_sender.sender.get_next_nonce()
+    assert transaction.nonce == 1234
 
 
 def test_transaction_sending(
@@ -133,7 +133,7 @@ def test_transaction_sending(
     validator_address,
 ):
     transaction = confirmation_sender.sender.prepare_confirmation_transaction(
-        transfer_event
+        transfer_event, nonce=confirmation_sender.sender.get_next_nonce()
     )
     confirmation_sender.sender.send_confirmation_transaction(transaction)
     assert transaction == confirmation_sender.pending_transaction_queue.peek()


### PR DESCRIPTION
This is based on PR #336, please only review the last commit.

This protects against confirming transfers that were not sent to the foreign bridge. We immediately stop the program in that case.

