### PR TITLE
Low balance pausing

### DIFF
--- a/tools/bridge/bridge/config.py
+++ b/tools/bridge/bridge/config.py
@@ -96,10 +96,10 @@ OPTIONAL_CONFIG_ENTRIES_WITH_DEFAULTS: Dict[str, Any] = {
     "foreign_chain_max_reorg_depth": 10,
     "foreign_chain_event_poll_interval": 5,
     "foreign_chain_event_fetch_start_block_number": 0,
+    "balance_warn_poll_interval": 60,
     # disable type check as type hint in eth_utils is wrong, (see
     # https://github.com/ethereum/eth-utils/issues/168)
-    "balance_warn_threshold": to_wei(0.1, "ether"),  # type: ignore
-    "balance_warn_poll_interval": 60,
+    "minimum_validator_balance": to_wei(0.04, "ether"),  # type: ignore
 }
 
 CONFIG_ENTRY_VALIDATORS = {
@@ -119,8 +119,8 @@ CONFIG_ENTRY_VALIDATORS = {
     "foreign_bridge_contract_address": validate_checksum_address,
     "foreign_chain_event_fetch_start_block_number": validate_non_negative_integer,
     "validator_private_key": validate_private_key,
-    "balance_warn_threshold": validate_non_negative_integer,
     "balance_warn_poll_interval": validate_positive_float,
+    "minimum_validator_balance": validate_positive_float,
 }
 
 assert all(key in CONFIG_ENTRY_VALIDATORS for key in REQUIRED_CONFIG_ENTRIES)

--- a/tools/bridge/bridge/events.py
+++ b/tools/bridge/bridge/events.py
@@ -1,0 +1,27 @@
+from abc import ABC
+
+import attr
+from web3.datastructures import AttributeDict
+
+
+class Event(ABC):
+    pass
+
+
+# Register AttributeDict as a subclass of Event as it is used to represent contract events in
+# web3.py
+Event.register(AttributeDict)
+
+
+class ControlEvent(Event, ABC):
+    pass
+
+
+@attr.s(auto_attribs=True)
+class BalanceCheck(ControlEvent):
+    balance: int
+
+
+@attr.s(auto_attribs=True)
+class IsValidatorCheck(ControlEvent):
+    is_validator: bool

--- a/tools/bridge/bridge/transfer_recorder.py
+++ b/tools/bridge/bridge/transfer_recorder.py
@@ -1,6 +1,8 @@
-from typing import Dict, List, Set
+import logging
+from typing import Dict, List, Optional, Set
 
 from eth_typing import Hash32
+from eth_utils import from_wei
 from web3.datastructures import AttributeDict
 
 from bridge.constants import (
@@ -8,11 +10,14 @@ from bridge.constants import (
     CONFIRMATION_EVENT_NAME,
     TRANSFER_EVENT_NAME,
 )
+from bridge.events import BalanceCheck, ControlEvent, IsValidatorCheck
 from bridge.utils import compute_transfer_hash
+
+logger = logging.getLogger(__name__)
 
 
 class TransferRecorder:
-    def __init__(self) -> None:
+    def __init__(self, minimum_balance: int) -> None:
         self.transfer_events: Dict[Hash32, AttributeDict] = {}
 
         self.transfer_hashes: Set[Hash32] = set()
@@ -23,13 +28,18 @@ class TransferRecorder:
 
         self.home_chain_synced_until = 0.0
 
-        self.is_validating = False
+        self.minimum_balance = minimum_balance
 
-    def start_validating(self) -> None:
-        if self.is_validating:
-            raise ValueError("Validator is already validating")
+        self.is_validator: Optional[bool] = None
+        self.balance: Optional[int] = None
 
-        self.is_validating = True
+    @property
+    def is_validating(self):
+        return self.is_validator and self.is_balance_sufficient
+
+    @property
+    def is_balance_sufficient(self):
+        return self.balance is not None and self.balance >= self.minimum_balance
 
     def apply_proper_event(self, event: AttributeDict) -> None:
         event_name = event.event
@@ -48,6 +58,37 @@ class TransferRecorder:
             self.completion_hashes.add(transfer_hash)
         else:
             raise ValueError(f"Got unknown event {event}")
+
+    def apply_control_event(self, event: ControlEvent) -> None:
+        if isinstance(event, IsValidatorCheck):
+            if event.is_validator and not self.is_validator:
+                logger.info("Account is a member of the validator set")
+                self.is_validator = True
+            elif not event.is_validator and self.is_validator:
+                logger.info("Account is not a member of the validator set")
+                self.is_validator = False
+
+        elif isinstance(event, BalanceCheck):
+            balance_sufficient_before = self.is_balance_sufficient
+            self.balance = event.balance
+            balance_sufficient_now = self.is_balance_sufficient
+
+            if not balance_sufficient_now:
+                logger.warn(
+                    f"Balance of validator account is only {from_wei(self.balance, 'ether')} TLC."
+                    f"Transfers will only be confirmed if it is at least "
+                    f"{from_wei(self.minimum_balance, 'ether')} TLC."
+                )
+
+            if not balance_sufficient_before and balance_sufficient_now:
+                logger.info(
+                    f"Validator account balance has increased to "
+                    f"{from_wei(self.balance, 'ether')} TLC which is above the minimum of "
+                    f"{from_wei(self.minimum_balance, 'ether')} TLC. Transfers will be confirmed."
+                )
+
+        else:
+            raise ValueError(f"Received unknown event {event}")
 
     def clear_transfers(self) -> None:
         transfer_hashes_to_remove = self.transfer_hashes & self.completion_hashes

--- a/tools/bridge/bridge/validator_balance_watcher.py
+++ b/tools/bridge/bridge/validator_balance_watcher.py
@@ -1,27 +1,21 @@
 import logging
 
 import gevent
-from eth_utils import from_wei
+
+from bridge.events import BalanceCheck
 
 logger = logging.getLogger(__name__)
 
 
 class ValidatorBalanceWatcher:
-    def __init__(
-        self, w3, validator_address, poll_interval, balance_warn_threshold
-    ) -> None:
+    def __init__(self, w3, validator_address, poll_interval, control_queue) -> None:
         self.w3 = w3
         self.validator_address = validator_address
         self.poll_interval = poll_interval
-        self.balance_warn_threshold = balance_warn_threshold
+        self.control_queue = control_queue
 
     def run(self) -> None:
         while True:
             current_balance = self.w3.eth.getBalance(self.validator_address)
-            if current_balance < self.balance_warn_threshold:
-                logger.warn(
-                    f"Low balance of validator account: {from_wei(current_balance, 'ether')} "
-                    f"TLC"
-                )
-
+            self.control_queue.put(BalanceCheck(current_balance))
             gevent.sleep(self.poll_interval)

--- a/tools/bridge/bridge/validator_status_watcher.py
+++ b/tools/bridge/bridge/validator_status_watcher.py
@@ -4,6 +4,8 @@ import gevent
 import tenacity
 from eth_utils import is_canonical_address, to_checksum_address
 
+from bridge.events import IsValidatorCheck
+
 logger = logging.getLogger(__name__)
 
 retry = tenacity.retry(
@@ -18,7 +20,7 @@ class ValidatorStatusWatcher:
         validator_proxy_contract,
         validator_address,
         poll_interval,
-        start_validating_callback,
+        control_queue,
         stop_validating_callback,
     ) -> None:
         self.validator_proxy_contract = validator_proxy_contract
@@ -27,7 +29,7 @@ class ValidatorStatusWatcher:
         self.validator_address = validator_address
 
         self.poll_interval = poll_interval
-        self.start_validating_callback = start_validating_callback
+        self.control_queue = control_queue
         self.stop_validating_callback = stop_validating_callback
 
     def _wait_for_validator_status(self):
@@ -46,9 +48,13 @@ class ValidatorStatusWatcher:
             gevent.sleep(self.poll_interval)
 
     def run(self) -> None:
-        self._wait_for_validator_status()
+        is_validator_from_beginning = self.check_validator_status()
+        self.control_queue.put(IsValidatorCheck(is_validator_from_beginning))
+
+        if not is_validator_from_beginning:
+            self._wait_for_validator_status()
+            self.control_queue.put(IsValidatorCheck(True))
         logger.info("The account is a member of the validator set")
-        self.start_validating_callback()
 
         gevent.sleep(self.poll_interval)  # wait until we poll again
         self._wait_for_non_validator_status()
@@ -57,7 +63,7 @@ class ValidatorStatusWatcher:
             f"The account with address {to_checksum_address(self.validator_address)} has lost it's"
             f"validator status. The program will be shutdown now. "
         )
-
+        self.control_queue.put(IsValidatorCheck(False))
         self.stop_validating_callback()
 
     @retry

--- a/tools/bridge/tests/test_validator_balance_watcher.py
+++ b/tools/bridge/tests/test_validator_balance_watcher.py
@@ -1,0 +1,60 @@
+import gevent
+import pytest
+from gevent.queue import Queue
+
+from bridge.events import BalanceCheck
+from bridge.validator_balance_watcher import ValidatorBalanceWatcher
+
+
+@pytest.fixture
+def poll_interval():
+    return 0.1
+
+
+@pytest.fixture
+def control_queue():
+    return Queue()
+
+
+@pytest.fixture
+def address(accounts):
+    return accounts[0]
+
+
+@pytest.fixture
+def another_address(accounts):
+    return accounts[1]
+
+
+@pytest.fixture
+def watcher(w3_home, address, poll_interval, control_queue, spawn):
+    watcher = ValidatorBalanceWatcher(
+        w3=w3_home,
+        validator_address=address,
+        poll_interval=poll_interval,
+        control_queue=control_queue,
+    )
+    spawn(watcher.run)
+    yield watcher
+
+
+def test_balance_watcher(
+    w3_home, watcher, poll_interval, address, another_address, control_queue
+):
+    initial_balance = w3_home.eth.getBalance(address)
+    gevent.sleep(poll_interval * 2.1)
+
+    w3_home.eth.sendTransaction(
+        {"from": address, "value": 1, "gasPrice": 0, "to": another_address}
+    )
+    new_balance = initial_balance - 1
+    gevent.sleep(poll_interval * 2.1)
+
+    events = []
+    while not control_queue.empty():
+        events.append(control_queue.get_nowait())
+
+    assert len(events) >= 4
+    assert all(isinstance(event, BalanceCheck) for event in events)
+    assert events[:2] == [BalanceCheck(initial_balance)] * 2
+    assert events[-2:] == [BalanceCheck(new_balance)] * 2

--- a/tools/bridge/tests/test_validator_status_watcher.py
+++ b/tools/bridge/tests/test_validator_status_watcher.py
@@ -2,65 +2,71 @@ from unittest.mock import Mock
 
 import gevent
 from eth_utils import to_canonical_address
+from gevent import Timeout
+from gevent.queue import Queue
 
+from bridge.events import IsValidatorCheck
 from bridge.validator_status_watcher import ValidatorStatusWatcher
 
 
 def test_watcher_checks_initial_validator_status_correctly(
     validator_proxy_with_validators, validator_address, spawn
 ):
-    start_callback = Mock()
+    control_queue = Queue()
     stop_callback = Mock()
     validator_status_watcher = ValidatorStatusWatcher(
         validator_proxy_with_validators,
         to_canonical_address(validator_address),
         poll_interval=1,
-        start_validating_callback=start_callback,
+        control_queue=control_queue,
         stop_validating_callback=stop_callback,
     )
 
     spawn(validator_status_watcher.run)
-    gevent.sleep(0.01)
-    start_callback.assert_called_once()
+    with Timeout(0.1):
+        initial_status_check = control_queue.get()
+    assert initial_status_check == IsValidatorCheck(True)
     stop_callback.assert_not_called()
 
 
 def test_watcher_checks_initial_non_validator_status_correctly(
     validator_proxy_with_validators, non_validator_address, spawn
 ):
-    start_callback = Mock()
+    control_queue = Queue()
     stop_callback = Mock()
     validator_status_watcher = ValidatorStatusWatcher(
         validator_proxy_with_validators,
         to_canonical_address(non_validator_address),
         poll_interval=1,
-        start_validating_callback=start_callback,
+        control_queue=control_queue,
         stop_validating_callback=stop_callback,
     )
 
     spawn(validator_status_watcher.run)
-    gevent.sleep(0.01)
-    start_callback.assert_not_called()
+    with Timeout(0.1):
+        initial_status_check = control_queue.get()
+    assert initial_status_check == IsValidatorCheck(False)
     stop_callback.assert_not_called()
 
 
 def test_watcher_notices_validator_set_joining(
     validator_proxy_contract, non_validator_address, system_address, spawn
 ):
-    start_callback = Mock()
+    control_queue = Queue()
     stop_callback = Mock()
     poll_interval = 0.1
     validator_status_watcher = ValidatorStatusWatcher(
         validator_proxy_contract,
         to_canonical_address(non_validator_address),
         poll_interval=poll_interval,
-        start_validating_callback=start_callback,
+        control_queue=control_queue,
         stop_validating_callback=stop_callback,
     )
 
     spawn(validator_status_watcher.run)
-    gevent.sleep(0.01)  # check initial status
-    start_callback.assert_not_called()
+    with Timeout(0.1):
+        initial_status_check = control_queue.get()
+    assert initial_status_check == IsValidatorCheck(False)
     stop_callback.assert_not_called()
 
     # join validator set
@@ -69,30 +75,31 @@ def test_watcher_notices_validator_set_joining(
     ).transact({"from": system_address})
 
     gevent.sleep(poll_interval * 1.5)  # check a second time
-    start_callback.assert_called_once()
+    with Timeout(0.1):
+        initial_status_check = control_queue.get()
+    assert initial_status_check == IsValidatorCheck(True)
     stop_callback.assert_not_called()
 
 
 def test_watcher_notices_validator_set_leaving(
     validator_proxy_with_validators, validator_address, system_address, spawn
 ):
-    start_callback = Mock()
+    control_queue = Queue()
     stop_callback = Mock()
     poll_interval = 0.1
     validator_status_watcher = ValidatorStatusWatcher(
         validator_proxy_with_validators,
         to_canonical_address(validator_address),
         poll_interval=poll_interval,
-        start_validating_callback=start_callback,
+        control_queue=control_queue,
         stop_validating_callback=stop_callback,
     )
 
     spawn(validator_status_watcher.run)
-    gevent.sleep(poll_interval * 0.01)  # check initial status
-    start_callback.assert_called_once()
+    with Timeout(0.1):
+        initial_status_check = control_queue.get()
+    assert initial_status_check == IsValidatorCheck(True)
     stop_callback.assert_not_called()
-
-    start_callback.reset_mock()
 
     # leave validator set
     validator_proxy_with_validators.functions.updateValidators([]).transact(
@@ -100,5 +107,7 @@ def test_watcher_notices_validator_set_leaving(
     )
 
     gevent.sleep(poll_interval)  # check a second time
-    start_callback.assert_not_called()
+    with Timeout(0.1):
+        initial_status_check = control_queue.get()
+    assert initial_status_check == IsValidatorCheck(False)
     stop_callback.assert_called_once()


### PR DESCRIPTION
Pause the confirmation sender if the balance gets too low. The minimum balance can be configured, but has a default of 0.04TLC, which corresponds to a little more than 10 confirmation transactions at the default gas limit.

To limit the number of callbacks, I've introduced a controller queue that the validator status watcher and the validator balance watcher use to push updates to a controller greenlet, which then turns the confirmation task planner on and off accordingly (we've discussed something like this before, but now I think it's worth the additional queue.).

Closes #328