### PR TITLE
Unify queue handling planner

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -70,6 +70,7 @@ PyYAML==5.1.2
 requests==2.22.0
 rlp==1.1.0
 semantic-version==2.6.0
+setproctitle==1.1.10
 setuptools==41.0.1
 setuptools-scm==3.3.3
 six==1.12.0

--- a/tools/bridge/bridge/boot.py
+++ b/tools/bridge/bridge/boot.py
@@ -10,6 +10,7 @@ import os
 import sys
 
 import gevent
+import setproctitle
 
 LOGFORMAT = "%(asctime)-15s %(levelname)-8s[%(greenlet)s] %(name)s: %(message)s"
 
@@ -32,7 +33,7 @@ def setup_basic_logging():
 
 def main():
     setup_basic_logging()
-
+    setproctitle.setproctitle("tlbc-bridge")
     from bridge import main
 
     main.main()

--- a/tools/bridge/bridge/boot.py
+++ b/tools/bridge/bridge/boot.py
@@ -1,0 +1,42 @@
+# boot the main program, let gevent do it's monkeypatching and setup
+# a greenlet aware custom logger class
+
+from gevent import monkey  # isort:skip
+
+monkey.patch_all()  # noqa: E402 isort:skip
+
+import logging
+import os
+import sys
+
+import gevent
+
+LOGFORMAT = "%(asctime)-15s %(levelname)-8s[%(greenlet)s] %(name)s: %(message)s"
+
+
+class CurrentGreenletLogger(logging.Logger):
+    def _log(self, level, msg, args, exc_info=None, extra=None):
+        if extra is None:
+            extra = {"greenlet": getattr(gevent.getcurrent(), "name", "main")}
+        super()._log(level, msg, args, exc_info, extra)
+
+
+def setup_basic_logging():
+    logging.setLoggerClass(CurrentGreenletLogger)
+    logging.basicConfig(
+        level=os.environ.get("LOGLEVEL", "INFO").upper(),
+        format=LOGFORMAT,
+        stream=sys.stdout,
+    )
+
+
+def main():
+    setup_basic_logging()
+
+    from bridge import main
+
+    main.main()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/bridge/bridge/confirmation_task_planner.py
+++ b/tools/bridge/bridge/confirmation_task_planner.py
@@ -4,6 +4,7 @@ import time
 from gevent.queue import Queue
 
 from bridge.event_fetcher import FetcherReachedHeadEvent
+from bridge.events import ChainRole
 from bridge.service import Service, run_services
 from bridge.transfer_recorder import TransferRecorder
 
@@ -30,39 +31,41 @@ class ConfirmationTaskPlanner:
         self.confirmation_task_queue = confirmation_task_queue
 
         self.services = [
-            Service("process-transfer-events", self.process_transfer_events),
-            Service("process-home-bridge-events", self.process_home_bridge_events),
-            Service("process-control-events", self.process_control_events),
+            Service(
+                "process-transfer-events",
+                self.process_events_from_queue,
+                self.transfer_event_queue,
+            ),
+            Service(
+                "process-home-bridge-events",
+                self.process_events_from_queue,
+                self.home_bridge_event_queue,
+            ),
+            Service(
+                "process-control-events",
+                self.process_events_from_queue,
+                self.control_queue,
+            ),
         ]
 
     def run(self):
         run_services(self.services)
 
-    def process_transfer_events(self) -> None:
+    def process_events_from_queue(self, queue) -> None:
         while True:
-            event = self.transfer_event_queue.get()
-            if isinstance(event, FetcherReachedHeadEvent):
-                logger.debug("Transfer events are in sync now")
-            else:
-                logger.debug("Received transfer to confirm")
-                self.recorder.apply_proper_event(event)
-
-    def process_home_bridge_events(self) -> None:
-        while True:
-            event = self.home_bridge_event_queue.get()
-            if isinstance(event, FetcherReachedHeadEvent):
-                logger.debug("Home bridge is in sync now")
+            event = queue.get()
+            self.recorder.apply_event(event)
+            if (
+                isinstance(event, FetcherReachedHeadEvent)
+                and event.chain_role == ChainRole.home
+            ):
+                logger.debug(
+                    "Home bridge is in sync now, last fetched reorg-safe block: %s",
+                    event.last_fetched_block_number,
+                )
                 # Let's check that this has not been for too long in the queue
                 if time.time() - event.timestamp < self.sync_persistence_time:
                     self.check_for_confirmation_tasks()
-            else:
-                logger.debug("Received home bridge event")
-                self.recorder.apply_proper_event(event)
-
-    def process_control_events(self) -> None:
-        while True:
-            event = self.control_queue.get()
-            self.recorder.apply_control_event(event)
 
     def check_for_confirmation_tasks(self) -> None:
         confirmation_tasks = self.recorder.pull_transfers_to_confirm()

--- a/tools/bridge/bridge/main.py
+++ b/tools/bridge/bridge/main.py
@@ -1,7 +1,3 @@
-from gevent import monkey  # isort:skip
-
-monkey.patch_all()  # noqa: E402 isort:skip
-
 import logging
 import logging.config
 import os
@@ -44,7 +40,6 @@ logger = logging.getLogger(__name__)
 def configure_logging(config):
     """configure the logging subsystem via the 'logging' key in the TOML config"""
     try:
-        logging.basicConfig(level=os.environ.get("LOGLEVEL", "INFO").upper())
         logging.config.dictConfig(config["logging"])
     except (ValueError, TypeError, AttributeError, ImportError) as err:
         click.echo(
@@ -250,6 +245,7 @@ def main(ctx, config_path: str) -> None:
     """
 
     try:
+        logger.info(f"Loading configuration file from {config_path}")
         config = load_config(config_path)
     except TomlDecodeError as decode_error:
         raise click.UsageError(f"Invalid config file: {decode_error}") from decode_error

--- a/tools/bridge/bridge/service.py
+++ b/tools/bridge/bridge/service.py
@@ -1,0 +1,33 @@
+import logging
+
+import gevent
+
+logger = logging.getLogger(__name__)
+
+
+class Service:
+    def __init__(self, name: str, run, *args, **kwargs):
+        self.name = name
+        self.run = run
+        self.args = args
+        self.kwargs = kwargs
+
+
+def start_services(services, start=gevent.Greenlet.start):
+    greenlets = []
+    for s in services:
+        logger.info(f"Starting {s.name} service")
+        gr = gevent.Greenlet(s.run, *s.args, **s.kwargs)
+        gr.name = s.name
+        start(gr)
+        greenlets.append(gr)
+    return greenlets
+
+
+def run_services(services):
+    try:
+        greenlets = start_services(services)
+        gevent.joinall(greenlets, raise_error=True)
+    finally:
+        for greenlet in greenlets:
+            greenlet.kill()

--- a/tools/bridge/bridge/transfer_recorder.py
+++ b/tools/bridge/bridge/transfer_recorder.py
@@ -10,7 +10,12 @@ from bridge.constants import (
     CONFIRMATION_EVENT_NAME,
     TRANSFER_EVENT_NAME,
 )
-from bridge.events import BalanceCheck, ControlEvent, IsValidatorCheck
+from bridge.events import (
+    BalanceCheck,
+    ControlEvent,
+    FetcherReachedHeadEvent,
+    IsValidatorCheck,
+)
 from bridge.utils import compute_transfer_hash
 
 logger = logging.getLogger(__name__)
@@ -87,6 +92,16 @@ class TransferRecorder:
                     f"{from_wei(self.minimum_balance, 'ether')} TLC. Transfers will be confirmed."
                 )
 
+        else:
+            raise ValueError(f"Received unknown event {event}")
+
+    def apply_event(self, event):
+        if isinstance(event, ControlEvent):
+            self.apply_control_event(event)
+        elif isinstance(event, FetcherReachedHeadEvent):
+            pass
+        elif isinstance(event, AttributeDict):
+            self.apply_proper_event(event)
         else:
             raise ValueError(f"Received unknown event {event}")
 

--- a/tools/bridge/requirements.txt
+++ b/tools/bridge/requirements.txt
@@ -6,6 +6,7 @@ toml
 web3
 validators
 tenacity
+setproctitle
 
 # --- development dependencies:
 

--- a/tools/bridge/setup.cfg
+++ b/tools/bridge/setup.cfg
@@ -17,7 +17,7 @@ packages = bridge
 
 [options.entry_points]
 console_scripts =
-    tlbc-bridge = bridge.main:main
+    tlbc-bridge = bridge.boot:main
 
 [flake8]
 max-line-length = 119

--- a/tools/bridge/setup.cfg
+++ b/tools/bridge/setup.cfg
@@ -13,6 +13,8 @@ install_requires =
     web3>=5.0,<5.1
     validators>=0.13,<0.14
     tenacity>=5.1.1,<5.2
+    setproctitle>=1.1.10,<1.2
+
 packages = bridge
 
 [options.entry_points]


### PR DESCRIPTION
this is based on PR #349

Unify queue handling in ConfirmationTaskPlanner
    
Simplify the ConfirmationTaskPlanner. There's no good reason why we
should have more than one function that feeds events from a queue to
the recorder.
