### PR TITLE
Bridge end2end tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
 VIRTUAL_ENV ?= $(shell pwd)/venv
 
 SUBDIRS = tools/auction-deploy tools/bridge-deploy tools/validator-set-deploy tools/quickstart tools/bridge contracts
+SUBDIRS_E2E = tools/bridge
 
 .PHONY: help
 help:
-	@echo "You can build any of the following targets. The clean, install, lint and test targets will run those targets for all subfolders.  The clean-*, install-*, lint-*, test-* targets will will run in the respective subfolder only:\n" |fold -s
+	@echo "You can build any of the following targets. The clean, install, lint test and test-end2end targets will run those targets for all subfolders.  The clean-*, install-*, lint-*, test-*, test-end2end-* targets will run in the respective subfolder only:\n" |fold -s
 
 	@$(MAKE) -pRrq -f $(lastword $(MAKEFILE_LIST)) : 2>/dev/null | awk -v RS= -F: '/^# File/,/^# Finished Make data base/ {if ($$1 !~ "^[#.]") {print $$1}}' | sort | egrep -v -e '^[^[:alnum:]]' -e '^$@$$'
 
@@ -39,6 +40,12 @@ $(SUB_TEST): test-%: setup-venv
 	$(MAKE) -C $* test
 .PHONY: test $(SUB_TEST)
 
+SUB_TEST_E2E = $(addprefix test-end2end-,$(SUBDIRS_E2E))
+test-end2end: setup-venv $(SUB_TEST_E2E)
+$(SUB_TEST_E2E): test-end2end-%: setup-venv
+	@echo "==> End2end testing $*"
+	$(MAKE) -C $* test-end2end
+.PHONY: test-end2end $(SUB_TEST_E2E)
 
 $(VIRTUAL_ENV):
 	@echo "==> Creating virtualenv in $(VIRTUAL_ENV)"

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,7 @@ ignore =
        E203
 
 [tool:pytest]
+addopts = --contracts-dir contracts/contracts
 
 [isort]
 line_length = 88

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,9 +9,6 @@ ignore =
        # black does it right, but flake8 wrongly complains
        E203
 
-[tool:pytest]
-addopts = --contracts-dir contracts/contracts
-
 [isort]
 line_length = 88
 known_future_library = future

--- a/tools/bridge/Makefile
+++ b/tools/bridge/Makefile
@@ -2,15 +2,18 @@ TOP_LEVEL=$(shell cd ../..; pwd)
 VIRTUAL_ENV ?= $(TOP_LEVEL)/venv
 
 lint: install-requirements
-	$(VIRTUAL_ENV)/bin/flake8 bridge tests setup.py
-	$(VIRTUAL_ENV)/bin/black --check bridge tests setup.py
-	$(VIRTUAL_ENV)/bin/mypy bridge tests setup.py --ignore-missing-imports
+	$(VIRTUAL_ENV)/bin/flake8 bridge tests end2end-tests setup.py
+	$(VIRTUAL_ENV)/bin/black --check bridge tests end2end-tests setup.py
+	$(VIRTUAL_ENV)/bin/mypy bridge tests end2end-tests/tests setup.py --ignore-missing-imports
 
 format:
-	$(VIRTUAL_ENV)/bin/black bridge tests setup.py
+	$(VIRTUAL_ENV)/bin/black bridge tests end2end-tests setup.py
 
 test: install-requirements install
 	$(VIRTUAL_ENV)/bin/python ./pytest tests
+
+test-end2end: install-requirements install
+	$(VIRTUAL_ENV)/bin/python pytest end2end-tests/tests
 
 build: install
 	$(VIRTUAL_ENV)/bin/python setup.py sdist

--- a/tools/bridge/end2end-tests/tests/test_transfer.py
+++ b/tools/bridge/end2end-tests/tests/test_transfer.py
@@ -1,0 +1,427 @@
+import os
+import subprocess
+import time
+import warnings
+from subprocess import Popen
+
+import pytest
+import requests
+from deploy_tools import deploy_compiled_contract
+from deploy_tools.deploy import wait_for_successful_transaction_receipt
+from web3 import HTTPProvider, Web3
+from web3.contract import Contract
+from web3.middleware import construct_sign_and_send_raw_middleware
+
+PARITY_DEV_ACCOUNT = "0x00a329c0648769A73afAc7F9381E08FB43dBEA72"
+PARITY_DEV_KEY = "0x4D5DB4107D237DF6A3D58EE5F70AE63D73D7658D4026F2EEFD2F204C81682CB7"
+
+HOME_RPC_URL = "http://localhost:8545"
+FOREIGN_RPC_URL = "http://localhost:8645"
+
+START_WEI_PER_ACCOUNT = 1 * 10 ** 18
+BRIDGE_FUNDS = 1_000_000 * 10 ** 18
+
+
+class TimeoutException(Exception):
+    pass
+
+
+class Timer:
+    def __init__(self, timeout):
+        self.start_time = None
+        self.timeout = timeout
+
+    def start(self):
+        self.start_time = time.time()
+
+    def is_timed_out(self):
+        if self.start_time is None:
+            raise ValueError("Timer is not started yet")
+        return self.time_passed > self.timeout
+
+    @property
+    def time_passed(self):
+        return time.time() - self.start_time
+
+
+def assert_within_timeout(check_function, timeout, poll_period=0.5):
+    """
+    Runs a check_function with assertions and give it some time to pass
+    :param check_function: The function which will be periodically called. It should contain some assertions
+    :param timeout: After this timeout non passing assertion will be raised
+    :param poll_period: poll interval to check the check_function
+    """
+    timer = Timer(timeout)
+    timer.start()
+
+    while True:
+        try:
+            check_function()
+        except AssertionError as e:
+            if not timer.is_timed_out():
+                time.sleep(poll_period)
+            else:
+                raise TimeoutException(
+                    f"Assertion did not pass after {timeout} seconds. See causing exception for more details."
+                ) from e
+        else:
+            break
+
+
+class Service:
+    def __init__(
+        self,
+        args,
+        *,
+        name=None,
+        env=None,
+        uptest_function=None,
+        timeout=5,
+        poll_interval=0.2,
+        process_settings=None,
+    ):
+        self.args = args
+        self.name = name
+        self.env = env
+        self.timeout = timeout
+        self.poll_interval = poll_interval
+        self._uptest_function = uptest_function
+        self.process = None
+        self._process_settings = process_settings
+
+        if self._process_settings is None:
+            self._process_settings = {}
+
+    def start(self):
+        """Starts the service and wait for it to be up """
+        self.process = Popen(self.args, env=self.env, **self._process_settings)
+        self._wait_for_up()
+        return self.process
+
+    def is_up(self):
+        """Use the uptest to determine if the service is up"""
+        if self._uptest_function is not None:
+            return self._uptest_function
+        else:
+            return True
+
+    def _wait_for_up(self):
+        start_time = time.time()
+        while True:
+            is_up = self.is_up()
+
+            if not is_up:
+                if time.time() - start_time > self.timeout:
+                    raise TimeoutException(
+                        f"Service {self.name} did not report to be up after {self.timeout} seconds"
+                    )
+                time.sleep(self.poll_interval)
+            else:
+                break
+
+    def terminate(self):
+        try:
+            self.process.terminate()
+            self.process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            warnings.warn(f"{self.name} did not terminate in time and had to be killed")
+            self.process.kill()
+            self.process.wait()
+
+
+class Node(Service):
+    def __init__(self, path, *, name=None, port_shift=0):
+
+        super().__init__(
+            [
+                "parity",
+                "-d",
+                str(path),
+                "--config",
+                "dev-insecure",
+                "--ports-shift",
+                f"{port_shift}",
+            ],
+            name=name,
+        )
+        self.web3 = Web3(HTTPProvider(f"http://localhost:{8545+port_shift}"))
+
+    def is_up(self):
+        try:
+            version = self.web3.clientVersion
+            return bool(version)
+        except requests.exceptions.ConnectionError:
+            return False
+
+
+class Bridge(Service):
+    def __init__(
+        self,
+        *,
+        name=None,
+        validator_private_key,
+        token_contract_address,
+        foreign_bridge_contract_address,
+        home_bridge_contract_address,
+    ):
+        env = {
+            "HOME_RPC_URL": HOME_RPC_URL,
+            "FOREIGN_RPC_URL": FOREIGN_RPC_URL,
+            "FOREIGN_CHAIN_TOKEN_CONTRACT_ADDRESS": str(token_contract_address),
+            "FOREIGN_BRIDGE_CONTRACT_ADDRESS": str(foreign_bridge_contract_address),
+            "FOREIGN_CHAIN_EVENT_FETCH_START_BLOCK_NUMBER": "0",
+            "HOME_BRIDGE_CONTRACT_ADDRESS": str(home_bridge_contract_address),
+            "HOME_CHAIN_EVENT_FETCH_START_BLOCK_NUMBER": "0",
+            "VALIDATOR_PRIVATE_KEY": validator_private_key.to_hex(),
+            "HOME_RPC_TIMEOUT": "10",
+            "HOME_CHAIN_MAX_REORG_DEPTH": "0",
+            "HOME_CHAIN_EVENT_POLL_INTERVAL": "1",
+            "FOREIGN_RPC_TIMEOUT": "10",
+            "FOREIGN_CHAIN_MAX_REORG_DEPTH": "3",
+            "FOREIGN_CHAIN_EVENT_POLL_INTERVAL": "1",
+        }
+        env.update(os.environ)
+        super().__init__(["tlbc-bridge"], env=env, name=name)
+
+    def is_up(self):
+        # TODO write uptest for the bridge
+        return True
+
+
+def mine_blocks(web3, number_of_blocks):
+    """Mines `number_of_blocks` blocks. Works by sending out transactions, assumes the parity InstaSeal engine"""
+
+    block_height = web3.eth.blockNumber
+    while web3.eth.blockNumber < block_height + number_of_blocks:
+        web3.eth.sendTransaction({"from": PARITY_DEV_ACCOUNT})
+
+    assert web3.eth.blockNumber == block_height + number_of_blocks
+
+
+@pytest.fixture(scope="session")
+def accounts(accounts):
+    return [PARITY_DEV_ACCOUNT] + list(accounts)
+
+
+@pytest.fixture(scope="session")
+def account_keys(account_keys):
+    return [PARITY_DEV_KEY] + list(account_keys)
+
+
+@pytest.fixture()
+def node_home(tmp_path_factory):
+    service = Node(
+        name="home-node",
+        port_shift=0,
+        path=tmp_path_factory.mktemp("node", numbered=True),
+    )
+    service.start()
+    yield service
+    service.terminate()
+
+
+@pytest.fixture()
+def node_foreign(tmp_path_factory):
+    service = Node(
+        name="foreign-node",
+        port_shift=100,
+        path=tmp_path_factory.mktemp("node", numbered=True),
+    )
+    service.start()
+    yield service
+    service.terminate()
+
+
+@pytest.fixture()
+def web3_home(node_home, accounts, account_keys):
+    web3 = Web3(HTTPProvider(HOME_RPC_URL))
+    web3.middleware_onion.add(construct_sign_and_send_raw_middleware(account_keys))
+    for account in accounts[1:]:
+        wait_for_successful_transaction_receipt(
+            web3,
+            web3.eth.sendTransaction(
+                {"from": accounts[0], "to": account, "value": START_WEI_PER_ACCOUNT}
+            ),
+        )
+    return web3
+
+
+@pytest.fixture()
+def web3_foreign(node_foreign, accounts, account_keys):
+    web3 = Web3(HTTPProvider(FOREIGN_RPC_URL))
+    web3.middleware_onion.add(construct_sign_and_send_raw_middleware(account_keys))
+    for account in accounts[1:]:
+        wait_for_successful_transaction_receipt(
+            web3,
+            web3.eth.sendTransaction(
+                {"from": accounts[0], "to": account, "value": START_WEI_PER_ACCOUNT}
+            ),
+        )
+    return web3
+
+
+@pytest.fixture
+def deploy_contract_on_chain(contract_assets, account_keys):
+    """A function that deploys a contract on a chain specified via a web3 instance."""
+
+    def deploy(
+        web3: Web3, contract_identifier: str, *, constructor_args=()
+    ) -> Contract:
+        return deploy_compiled_contract(
+            abi=contract_assets[contract_identifier]["abi"],
+            bytecode=contract_assets[contract_identifier]["bytecode"],
+            web3=web3,
+            constructor_args=constructor_args,
+            private_key=account_keys[0],
+        )
+
+    return deploy
+
+
+@pytest.fixture
+def token_contract(deploy_contract_on_chain, web3_foreign, accounts):
+    """The token contract on the foreign chain."""
+    constructor_args = (
+        "Trustlines Network Token",
+        "TLN",
+        18,
+        accounts[0],
+        BRIDGE_FUNDS,
+    )
+
+    token_contract = deploy_contract_on_chain(
+        web3_foreign, "TrustlinesNetworkToken", constructor_args=constructor_args
+    )
+
+    assert token_contract.functions.balanceOf(accounts[0]).call() > 0
+
+    for account in accounts[1:]:
+        wait_for_successful_transaction_receipt(
+            web3_foreign,
+            token_contract.functions.transfer(account, 10 ** 18).transact(
+                {"from": accounts[0]}
+            ),
+        )
+
+    return token_contract
+
+
+@pytest.fixture
+def foreign_bridge_contract(deploy_contract_on_chain, web3_foreign, token_contract):
+    """The foreign bridge contract."""
+    return deploy_contract_on_chain(
+        web3_foreign, "ForeignBridge", constructor_args=(token_contract.address,)
+    )
+
+
+@pytest.fixture()
+def validators(accounts):
+    return accounts[7:10]
+
+
+@pytest.fixture()
+def validator_keys(account_keys):
+    return account_keys[7:10]
+
+
+@pytest.fixture
+def system_address(accounts):
+    """Address pretending to be the system address."""
+    return accounts[0]
+
+
+@pytest.fixture
+def validator_proxy_contract(deploy_contract_on_chain, web3_home, system_address):
+    """The plain validator proxy contract."""
+    contract = deploy_contract_on_chain(
+        web3_home, "TestValidatorProxy", constructor_args=([], system_address)
+    )
+
+    assert contract.functions.systemAddress().call() == system_address
+
+    return contract
+
+
+@pytest.fixture
+def validator_proxy_with_validators(
+    validator_proxy_contract, system_address, validators
+):
+    """Validator proxy contract using the proxy validators."""
+    validator_proxy_contract.functions.updateValidators(validators).transact(
+        {"from": system_address}
+    )
+    return validator_proxy_contract
+
+
+@pytest.fixture
+def home_bridge_contract(
+    deploy_contract_on_chain, validator_proxy_with_validators, web3_home, accounts
+):
+    """The home bridge contract."""
+    contract = deploy_contract_on_chain(
+        web3_home,
+        "HomeBridge",
+        constructor_args=(validator_proxy_with_validators.address, 50),
+    )
+
+    wait_for_successful_transaction_receipt(
+        web3_home,
+        contract.functions.fund().transact(
+            {"from": accounts[0], "gas": 100_000, "value": BRIDGE_FUNDS}
+        ),
+    )
+
+    assert web3_home.eth.getBalance(contract.address) == BRIDGE_FUNDS
+
+    return contract
+
+
+@pytest.fixture()
+def bridges(
+    validator_keys, token_contract, home_bridge_contract, foreign_bridge_contract
+):
+    bridges = []
+    for i, key in enumerate(validator_keys):
+        bridge = Bridge(
+            validator_private_key=key,
+            token_contract_address=token_contract.address,
+            foreign_bridge_contract_address=foreign_bridge_contract.address,
+            home_bridge_contract_address=home_bridge_contract.address,
+            name=f"Bridge {i}",
+        )
+        bridge.start()
+        bridges.append(bridge)
+
+    yield
+
+    for bridge in bridges:
+        bridge.terminate()
+
+
+def test_transfer(
+    web3_home, web3_foreign, foreign_bridge_contract, token_contract, accounts, bridges
+):
+    sender = accounts[3]
+    value = 5000
+    foreign_balance_before = token_contract.functions.balanceOf(sender).call()
+    home_balance_before = web3_home.eth.getBalance(sender)
+
+    wait_for_successful_transaction_receipt(
+        web3_foreign,
+        token_contract.functions.transfer(
+            foreign_bridge_contract.address, value
+        ).transact({"from": sender}),
+    )
+
+    # reorg depth is 3
+    mine_blocks(web3_foreign, 3)
+
+    def check_balance():
+        foreign_balance_after = token_contract.functions.balanceOf(sender).call()
+        home_balance_after = web3_home.eth.getBalance(sender)
+
+        print("CHeck")
+        assert foreign_balance_before - foreign_balance_after == value
+        assert home_balance_before - home_balance_after == -value
+
+    assert_within_timeout(check_balance, 10)

--- a/tools/bridge/setup.cfg
+++ b/tools/bridge/setup.cfg
@@ -22,6 +22,9 @@ packages = bridge
 console_scripts =
     tlbc-bridge = bridge.boot:main
 
+[tool:pytest]
+addopts = --contracts-dir ../../contracts/contracts
+
 [flake8]
 max-line-length = 119
 ignore =


### PR DESCRIPTION
This adds a first simple end2end test for the bridge, which will just
test that in a setup with all validators online the transfer will be
completed.
However, this also should function as the blueprint for future end2end
tests. Please pay attention to how I tried to make the tests not flaky
by
  - Test a service to be "up" before proceeding
  - Having timeout tests for fast tests but non flakiness
Please make sure to keep those properties. So most most importantly do not use simple `time.sleep()` as those will either make the tests really slow, or flaky. 

How to run the tests:
you need `parity` and the `tlbc-bridge` installed, then simple run the tests with `pytest`

TODO/known issues. 

- Refactor the code into different files
- Let the tests be run by Circle CI
- Document how to run the tests
- Add uptest for the bridge
- Add more test cases (should be done in a different PR)
    - Less validators
    - What happens if restarted/stopped, backend node stopped and so on
    - ...
- On my machine for some reason parity has to always be killed with `SIGKILL`(automatically down by the tests), please let me know if that is the case for you too? There will be a warning in the test output if that happens. 

So if you want to take over please let me know what you will be working on. Ask me if something is unclear, I will be able to answer. 