### PR TITLE
Feature/bridge client nested environment variables

### DIFF
--- a/tools/bridge/.env.example
+++ b/tools/bridge/.env.example
@@ -19,4 +19,8 @@ HOME_BRIDGE_CONTRACT_ADDRESS=0x321b427210E706747129cfF9BC6A33607Ed86dff
 # The Deployment Block Number of the Bridge Contract on the Home Network
 HOME_CHAIN_EVENT_FETCH_START_BLOCK_NUMBER=3395992
 
-VALIDATOR_PRIVATE_KEY=
+# The validators private key to sign confirmation transactions.
+VALIDATOR_PRIVATE_KEY.RAW=
+# or
+# VALIDATOR_PRIVATE_KEY.KEYSTORE_PATH=/path/to/keystore.json
+# VALIDATOR_PRIVATE_KEY.KEYSTORE_PASSWORD_PATH=/path/to/keystore_password

--- a/tools/bridge/README.md
+++ b/tools/bridge/README.md
@@ -89,10 +89,11 @@ The bridge validator client can be configured in two different ways. Either by
 a TOML configuration file or via environment variables. Both can also be
 mixed, where the environment variables have priority. Environment variable names
 are equal to the ones in the TOML file but in upper case (e.g. `HOME_RPC_URL`).
+Special is the dot notation for [hierarchical options](#hierarchical-options).
 The `--config` (`-c`) CLI parameter allows to define the path to the
 configuration file.
 
-There are tools which make working with a set of environment variables a more pleasent experience.
+There are tools which make working with a set of environment variables a more pleasant experience.
 One of those is [dotenv](https://www.npmjs.com/package/dotenv-cli) which allows loading environment
 variables from a `.env` file, an example of which is provided [here](.env.example). To start the
 bridge with configuration from a `.env` file, run `dotenv tlbc-bridge`. Alternatively, you can
@@ -118,7 +119,26 @@ with a default value are optional.
 |  `home_chain_event_fetch_start_block_number`   |      `0`      |  block number from which on events should be fetched on home chain   |
 |             `home_chain_gas_price`             | `10000000000` |           gas price in GWei for confirmation transactions            |
 |            `validator_private_key`             |               |      section of the validators private key to confirm transfers      |
-|                   `logging`                    |               |             dictionary to configure [logging](#logging)              |
+|                   `logging`                    |               |               section to configure [logging](#logging)               |
+
+### Hierarchical Options
+
+When using hierarchical options like `logging` or `validator_private_key`, they
+must be defined as TOML sections. For the configuration with environment
+variables, the dot notation is supported. Therefore must each value contain its
+whole upper hierarchy as keys separated with dots. Outside of an `.env` file
+this will require the usage of the `env` command. The direct definition of a
+variable with dotted names is likely to not work. Multiple further example can
+be found within the following sections.
+
+```toml
+[logging.root]
+level="DEBUG"
+```
+
+```sh
+env LOGGING.ROOT.LEVEL="DEBUG" ... tlbc-bridge
+```
 
 ### Private Key
 
@@ -126,6 +146,8 @@ The private key of the validator to confirm transfers can be provided in two
 different ways. Either by its raw form as hex encoded string or in an encrypted
 keystore with an additional password file. In case both are defined, the raw
 version takes precedence.
+
+A configuration via TOML file looks like that:
 
 ```toml
 [validator_private_key]
@@ -135,10 +157,20 @@ keystore_path = "/path/to/keystore.json"
 keystore_password_path = "/path/to/keystore_password"
 ```
 
+A configuration via environment variables requires the following definitions:
+
+```sh
+VALIDATOR_PRIVATE_KEY.RAW="0x..."
+# or
+VALIDATOR_PRIVATE_KEY.KEYSTORE_PATH="/path/to/keystore.json"
+VALIDATOR_PRIVATE_KEY.KEYSTORE_PASSWORD_PATH="/path/to/keystore_password"
+```
+
 ### Logging
 
-Logging can be configured globally or for specific components by setting the
-`logging` key in the TOML configuration file:
+Logging can be configured globally or for specific components.
+
+A configuration via TOML file looks like that:
 
 ```toml
 [logging.root]
@@ -155,10 +187,22 @@ level = "INFO"
 level = "INFO"
 ```
 
+A configuration via environment variables requires the following definitions:
+
+```sh
+LOGGING.ROOT.LEVEL="DEBUG"
+LOGGING.LOGGERS.WEB3.LEVEL="INFO"
+LOGGING.LOGGERS.URLLIB3.LEVEL="INFO"
+```
+
 Internally this is using _Python_'s
 [logging.config.dictConfig](https://docs.python.org/3/library/logging.config.html#logging.config.dictConfig).
 The exact schema for this key can be found at the [configuration dictionary
 schema](https://docs.python.org/3/library/logging.config.html#logging-config-dictschema).
+
+**Note:**
+The dotted environment variable notation does not work everywhere. Values like
+`[logging.loggers."bridge.main"]` are not representable and would get split.
 
 ### Validation
 

--- a/tools/bridge/bridge/utils.py
+++ b/tools/bridge/bridge/utils.py
@@ -1,4 +1,5 @@
 import os
+from typing import Any, Dict
 
 from eth_keyfile import extract_key_from_keyfile
 from eth_typing import Hash32
@@ -63,3 +64,43 @@ def get_validator_private_key(config: dict) -> bytes:
             raise ValueError(
                 f"Could not decrypt keystore. Please make sure the password is correct."
             )
+
+
+def dotted_key_dict_to_nested_dict(dotted_key_dict):
+    """Convert a dictionary with dotted keys into a nested one.
+
+    Keys which include a dot are split and get replaced with dictionaries,
+    containing further keys. The origin purpose is to support dotted environment
+    variables in relation to configuration sections.
+    E.g.: {'a.b': 1, 'a.c': 2, 'd': 3} -> {'a': {'b': 1, 'c': 2}, 'd': 3}
+    """
+
+    nested_dict: Dict[str, Any] = {}
+
+    for key, value in dotted_key_dict.items():
+        deep_nested = nested_dict
+        subkey_list = key.split(".")
+
+        for subkey in subkey_list[:-1]:
+            if subkey not in deep_nested:
+                deep_nested[subkey] = {}
+
+            deep_nested = deep_nested[subkey]
+
+        deep_nested[subkey_list[-1]] = value
+
+    return nested_dict
+
+
+def lower_dict_keys(dictionary):
+    """Recursively change all dictionary keys to lower case."""
+
+    if not isinstance(dictionary, dict):
+        return dictionary
+
+    dictionary_copy = {}
+
+    for key, value in dictionary.items():
+        dictionary_copy[key.lower()] = lower_dict_keys(value)
+
+    return dictionary_copy

--- a/tools/bridge/tests/test_utils.py
+++ b/tools/bridge/tests/test_utils.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 
-from bridge.utils import get_validator_private_key
+from bridge.utils import dotted_key_dict_to_nested_dict, get_validator_private_key
 
 
 @pytest.fixture
@@ -114,3 +114,10 @@ def test_get_validator_private_key_kestore_not_matching_password(
 
     with pytest.raises(ValueError):
         get_validator_private_key(configuration_with_validator_private_key_keystore)
+
+
+def test_dotted_key_dict_to_nestd_dict():
+    dotted_key_dict = {"a.b": 1, "a.c": 2, "d": 3}
+    nested_dict = {"a": {"b": 1, "c": 2}, "d": 3}
+
+    assert dotted_key_dict_to_nested_dict(dotted_key_dict) == nested_dict


### PR DESCRIPTION
This is partially based on #362 
Please review/merge that PR first and focus on the last two commits only.
I do not feel 100% confident with this solution. More in general with the continuous support of environment variables for hierarchical options. Anyways I think using section <> dicts seem the best approach to handle more complex options like the private key. Therefore I hope this solution is good enough. Rather than only support the specific configuration sections, this should be a stable overall solution. Thereby also the logging can be configured via environment variables as well.