### PR TITLE
Enhance transfer recorder

### DIFF
--- a/tools/bridge/bridge/constants.py
+++ b/tools/bridge/bridge/constants.py
@@ -12,3 +12,5 @@ CONFIRMATION_TRANSACTION_GAS_LIMIT = 400_000
 
 # maximum amount of time in seconds application greenlets have to cleanup before shutdown
 APPLICATION_CLEANUP_TIMEOUT = 5
+
+ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"

--- a/tools/bridge/bridge/event_fetcher.py
+++ b/tools/bridge/bridge/event_fetcher.py
@@ -8,6 +8,7 @@ from web3.contract import Contract
 from web3.datastructures import AttributeDict
 
 from bridge.events import ChainRole, FetcherReachedHeadEvent
+from bridge.utils import sort_events
 
 
 class EventFetcher:
@@ -100,14 +101,7 @@ class EventFetcher:
             else:
                 self.logger.debug(f"Found {len(fetched_events)} {event_name} events.")
 
-        events.sort(
-            key=lambda event: (
-                event.blockNumber,
-                event.transactionIndex,
-                event.logIndex,
-            )
-        )
-
+        sort_events(events)
         return events
 
     def fetch_some_events(self) -> List:

--- a/tools/bridge/bridge/transfer_recorder.py
+++ b/tools/bridge/bridge/transfer_recorder.py
@@ -11,7 +11,7 @@ from bridge.constants import (
     TRANSFER_EVENT_NAME,
 )
 from bridge.events import BalanceCheck, Event, FetcherReachedHeadEvent, IsValidatorCheck
-from bridge.utils import compute_transfer_hash
+from bridge.utils import compute_transfer_hash, sort_events
 
 logger = logging.getLogger(__name__)
 
@@ -87,6 +87,7 @@ class TransferRecorder:
             confirmation_tasks = []
 
         self.clear_transfers()
+        sort_events(confirmation_tasks)
         return confirmation_tasks
 
     def apply_proper_event(self, event: AttributeDict) -> None:

--- a/tools/bridge/bridge/transfer_recorder.py
+++ b/tools/bridge/bridge/transfer_recorder.py
@@ -42,7 +42,7 @@ class TransferRecorder:
 
         balance_in_eth = (self.balance or 0) / 10 ** 18
         logger.info(
-            f"reportinging internal state\n\n"
+            f"reporting internal state\n\n"
             f"===== Internal state ===============================\n"
             f"    {validator_status}, balance {balance_in_eth} coins\n"
             f"    {len(self.transfer_events)} transfer events\n"

--- a/tools/bridge/bridge/transfer_recorder.py
+++ b/tools/bridge/bridge/transfer_recorder.py
@@ -40,11 +40,14 @@ class TransferRecorder:
         else:
             validator_status = "not validating"
 
-        balance_in_eth = (self.balance or 0) / 10 ** 18
+        if self.balance is None:
+            balance_str = "-unknown-"
+        else:
+            balance_str = f"{from_wei(self.balance, 'ether')}"
         logger.info(
             f"reporting internal state\n\n"
             f"===== Internal state ===============================\n"
-            f"    {validator_status}, balance {balance_in_eth} coins\n"
+            f"    {validator_status}, balance {balance_str} coins\n"
             f"    {len(self.transfer_events)} transfer events\n"
             f"    {len(self.scheduled_hashes)} scheduled for confirmation\n"
             f"    {len(self.completion_hashes)} completions seen\n"

--- a/tools/bridge/bridge/utils.py
+++ b/tools/bridge/bridge/utils.py
@@ -104,3 +104,9 @@ def lower_dict_keys(dictionary):
         dictionary_copy[key.lower()] = lower_dict_keys(value)
 
     return dictionary_copy
+
+
+def sort_events(events):
+    events.sort(
+        key=lambda event: (event.blockNumber, event.transactionIndex, event.logIndex)
+    )

--- a/tools/bridge/tests/test_confirmation_task_planner.py
+++ b/tools/bridge/tests/test_confirmation_task_planner.py
@@ -34,6 +34,9 @@ def get_transfer_event(transaction_hash: Hash32) -> AttributeDict:
             "event": TRANSFER_EVENT_NAME,
             "transactionHash": HexBytes(transaction_hash),
             "logIndex": 0,
+            "blockNumber": 1,
+            "transactionIndex": 0,
+            "logIndex": 0,
         }
     )
 

--- a/tools/bridge/tests/test_confirmation_task_planner.py
+++ b/tools/bridge/tests/test_confirmation_task_planner.py
@@ -33,10 +33,16 @@ def get_transfer_event(transaction_hash: Hash32) -> AttributeDict:
         {
             "event": TRANSFER_EVENT_NAME,
             "transactionHash": HexBytes(transaction_hash),
-            "logIndex": 0,
             "blockNumber": 1,
             "transactionIndex": 0,
             "logIndex": 0,
+            "args": AttributeDict(
+                {
+                    "from": "0x345DeAd084E056dc78a0832E70B40C14B6323458",
+                    "to": "0x1ADb0A4853bf1D564BbAD7565b5D50b33D20af60",
+                    "value": 1,
+                }
+            ),
         }
     )
 
@@ -124,9 +130,8 @@ def test_recorder_does_not_plan_transfers_twice(recorder, transfer_event):
 
 
 def test_recorder_does_not_plan_confirmed_transfer(recorder, transfer_hash, hashes):
-    transfer_event = get_transfer_hash_event(
-        TRANSFER_EVENT_NAME, transfer_hash, next(hashes)
-    )
+    transfer_event = get_transfer_event(transaction_hash=next(hashes))
+
     confirmation_event = get_transfer_hash_event(
         CONFIRMATION_EVENT_NAME, compute_transfer_hash(transfer_event), next(hashes)
     )
@@ -136,9 +141,7 @@ def test_recorder_does_not_plan_confirmed_transfer(recorder, transfer_hash, hash
 
 
 def test_recorder_does_not_plan_completed_transfer(recorder, transfer_hash, hashes):
-    transfer_event = get_transfer_hash_event(
-        TRANSFER_EVENT_NAME, transfer_hash, next(hashes)
-    )
+    transfer_event = get_transfer_event(transaction_hash=next(hashes))
     completion_event = get_transfer_hash_event(
         COMPLETION_EVENT_NAME, compute_transfer_hash(transfer_event), next(hashes)
     )
@@ -178,10 +181,7 @@ def test_recorder_not_validating_if_not_validator(recorder, minimum_balance):
 
 
 def test_transfer_recorder_drops_completed_transfers(recorder, hashes):
-    transfer_hash = next(hashes)
-    transfer_event = get_transfer_hash_event(
-        TRANSFER_EVENT_NAME, transfer_hash, next(hashes)
-    )
+    transfer_event = get_transfer_event(transaction_hash=next(hashes))
     completion_event = get_transfer_hash_event(
         COMPLETION_EVENT_NAME, compute_transfer_hash(transfer_event), next(hashes)
     )

--- a/tools/bridge/tests/test_transfer_recorder.py
+++ b/tools/bridge/tests/test_transfer_recorder.py
@@ -1,0 +1,130 @@
+import logging
+
+import pytest
+from hexbytes import HexBytes
+from web3.datastructures import AttributeDict
+
+from bridge.constants import ZERO_ADDRESS
+from bridge.events import BalanceCheck, IsValidatorCheck
+from bridge.transfer_recorder import TransferRecorder
+
+
+def make_event(
+    *,
+    _from="0x449458F2B2c67159A6E05166d4f80a5AC783182C",
+    _to="0xb4c79daB8f259C7Aee6E5b2Aa729821864227e84",
+    value=1200
+):
+    return AttributeDict(
+        {
+            "args": AttributeDict({"from": _from, "to": _to, "value": value}),
+            "event": "Transfer",
+            "logIndex": 0,
+            "transactionIndex": 0,
+            "transactionHash": HexBytes(
+                "0xc7452af2de5730003e4b0e0d6481338013c65299e91637c4db65923a41118339"
+            ),
+            "address": "0x731a10897d267e19B34503aD902d0A29173Ba4B1",
+            "blockHash": HexBytes(
+                "0xa16a2b925878cba9a5179e415ca3a76c44a15a103516c6263c7a151a134061f5"
+            ),
+            "blockNumber": 5574,
+        }
+    )
+
+
+@pytest.fixture()
+def transfer_event():
+    return AttributeDict(
+        {
+            "args": AttributeDict(
+                {
+                    "from": "0x449458F2B2c67159A6E05166d4f80a5AC783182C",
+                    "to": "0xb4c79daB8f259C7Aee6E5b2Aa729821864227e84",
+                    "value": 1200,
+                }
+            ),
+            "event": "Transfer",
+            "logIndex": 0,
+            "transactionIndex": 0,
+            "transactionHash": HexBytes(
+                "0xc7452af2de5730003e4b0e0d6481338013c65299e91637c4db65923a41118339"
+            ),
+            "address": "0x731a10897d267e19B34503aD902d0A29173Ba4B1",
+            "blockHash": HexBytes(
+                "0xa16a2b925878cba9a5179e415ca3a76c44a15a103516c6263c7a151a134061f5"
+            ),
+            "blockNumber": 5574,
+        }
+    )
+
+
+@pytest.fixture()
+def fresh_recorder():
+    return TransferRecorder(minimum_balance=10 ** 18)
+
+
+@pytest.fixture()
+def recorder():
+    recorder = TransferRecorder(minimum_balance=10 ** 18)
+    recorder.apply_event(BalanceCheck(balance=200 * 10 ** 18))
+    recorder.apply_event(IsValidatorCheck(is_validator=True))
+    return recorder
+
+
+def test_log_current_state_fresh(fresh_recorder, caplog):
+    caplog.set_level(logging.INFO)
+    fresh_recorder.log_current_state()
+    assert len(caplog.records) == 1
+    message = caplog.records[0].message
+    assert message.startswith("reporting internal state")
+    assert "not validating" in message
+    assert "balance -unknown-" in message
+
+
+def test_log_current_state(recorder, caplog):
+    caplog.set_level(logging.INFO)
+    recorder.log_current_state()
+    assert len(caplog.records) == 1
+    message = caplog.records[0].message
+    assert message.startswith("reporting internal state")
+    assert "not validating" not in message
+    assert "balance 2" in message
+
+
+def test_is_balance_sufficient(fresh_recorder):
+    assert not fresh_recorder.is_balance_sufficient
+    fresh_recorder.apply_event(BalanceCheck(balance=2 * 10 ** 18))
+    assert fresh_recorder.is_balance_sufficient
+
+    fresh_recorder.apply_event(BalanceCheck(balance=10 ** 15))
+    assert not fresh_recorder.is_balance_sufficient
+
+
+def test_is_validating(fresh_recorder):
+    assert not fresh_recorder.is_validating
+    fresh_recorder.apply_event(IsValidatorCheck(is_validator=True))
+    assert not fresh_recorder.is_validating
+    fresh_recorder.apply_event(BalanceCheck(balance=2 * 10 ** 18))
+    assert fresh_recorder.is_validating
+
+
+def test_skip_bad_transfer_zero_amount(recorder, transfer_event):
+    recorder.apply_event(make_event(value=0))
+    assert not recorder.transfer_events
+
+
+def test_skip_bad_transfer_zero_address(recorder, transfer_event):
+    recorder.apply_event(make_event(_from=ZERO_ADDRESS))
+    assert not recorder.transfer_events
+
+
+def test_recorder_pull_transfers(recorder):
+    event = make_event()
+    recorder.apply_event(event)
+    assert recorder.transfer_events
+    to_confirm = recorder.pull_transfers_to_confirm()
+    assert to_confirm == [event]
+
+    to_confirm = recorder.pull_transfers_to_confirm()
+    assert to_confirm == []


### PR DESCRIPTION
This enhance the transfer recorder a bit. It confirms transfers in the order they happened on the foreign chain and it ignores Transfer events with zero balance or zero recipient.

Also I've added some basic tests for the transfer recorder. I've only noticed afterwards the we do have some in `test_confirmation_task_planner`. We should probably move them to `test_transfer_recorder.py`
