### PR TITLE
Add a webservice providing information about the internal state

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -25,6 +25,7 @@ eth-rlp==0.1.2
 eth-tester==0.2.0b2
 eth-typing==2.1.0
 eth-utils==1.6.2
+falcon==2.0.0
 flake8==3.7.8
 flake8-polyfill==1.0.2
 gevent==1.4.0

--- a/tools/bridge/bridge/config.py
+++ b/tools/bridge/bridge/config.py
@@ -121,6 +121,13 @@ def validate_private_key(private_key: Any) -> dict:
     return private_key
 
 
+def validate_webservice(webservice_dict: Dict) -> Dict:
+    """validate the webservice dictionary"""
+    if not isinstance(webservice_dict, dict):
+        raise ValueError("webservice must be a dictionary")
+    return webservice_dict
+
+
 def validate_logging(logging_dict: Dict) -> Dict:
     """validate the logging dictionary
 
@@ -156,9 +163,11 @@ OPTIONAL_CONFIG_ENTRIES_WITH_DEFAULTS: Dict[str, Any] = {
     # disable type check as type hint in eth_utils is wrong, (see
     # https://github.com/ethereum/eth-utils/issues/168)
     "minimum_validator_balance": to_wei(0.04, "ether"),  # type: ignore
+    "webservice": {},
 }
 
 CONFIG_ENTRY_VALIDATORS = {
+    "webservice": validate_webservice,
     "logging": validate_logging,
     "home_rpc_url": validate_rpc_url,
     "home_rpc_timeout": validate_non_negative_integer,

--- a/tools/bridge/bridge/main.py
+++ b/tools/bridge/bridge/main.py
@@ -38,6 +38,7 @@ from bridge.service import Service, start_services
 from bridge.utils import get_validator_private_key
 from bridge.validator_balance_watcher import ValidatorBalanceWatcher
 from bridge.validator_status_watcher import ValidatorStatusWatcher
+from bridge.webservice import DummyWebservice, InternalState, Webservice
 
 logger = logging.getLogger(__name__)
 
@@ -234,6 +235,40 @@ def make_validator_balance_watcher(config, control_queue):
     )
 
 
+public_config_keys = (
+    "foreign_rpc_url",
+    "home_rpc_url",
+    "foreign_chain_max_reorg_depth",
+    "home_chain_max_reorg_depth",
+    "foreign_chain_token_contract_address",
+    "foreign_bridge_contract_address",
+    "home_bridge_contract_address",
+    "foreign_chain_event_fetch_start_block_number",
+    "home_chain_event_fetch_start_block_number",
+)
+
+
+def make_webservice(*, config, recorder):
+    d = config["webservice"]
+    if d["enabled"]:
+        ws = Webservice(host=d["host"], port=d["port"])
+    else:
+        ws = DummyWebservice()
+
+    def encode_address(v):
+        if isinstance(v, bytes):
+            return to_checksum_address(v)
+        else:
+            return v
+
+    public_config = {k: encode_address(config[k]) for k in public_config_keys}
+
+    ws.enable_internal_state(
+        InternalState(recorder=recorder, public_config=public_config)
+    )
+    return ws
+
+
 def stop(pool, timeout):
     logger.info("Stopping...")
 
@@ -353,6 +388,7 @@ def main(ctx, config_path: str) -> None:
     )
 
     validator_balance_watcher = make_validator_balance_watcher(config, control_queue)
+    webservice = make_webservice(config=config, recorder=recorder)
 
     services = (
         [
@@ -373,6 +409,7 @@ def main(ctx, config_path: str) -> None:
         + sender.services
         + watcher.services
         + confirmation_task_planner.services
+        + webservice.services
     )
 
     install_signal_handler(

--- a/tools/bridge/bridge/main.py
+++ b/tools/bridge/bridge/main.py
@@ -263,9 +263,7 @@ def make_webservice(*, config, recorder):
 
     public_config = {k: encode_address(config[k]) for k in public_config_keys}
 
-    ws.enable_internal_state(
-        InternalState(recorder=recorder, public_config=public_config)
-    )
+    ws.enable_internal_state(InternalState(recorder=recorder, config=public_config))
     return ws
 
 

--- a/tools/bridge/bridge/main.py
+++ b/tools/bridge/bridge/main.py
@@ -38,7 +38,7 @@ from bridge.service import Service, start_services
 from bridge.utils import get_validator_private_key
 from bridge.validator_balance_watcher import ValidatorBalanceWatcher
 from bridge.validator_status_watcher import ValidatorStatusWatcher
-from bridge.webservice import DummyWebservice, InternalState, Webservice
+from bridge.webservice import InternalState, Webservice
 
 logger = logging.getLogger(__name__)
 
@@ -250,10 +250,10 @@ public_config_keys = (
 
 def make_webservice(*, config, recorder):
     d = config["webservice"]
-    if d["enabled"]:
+    if d and d["enabled"]:
         ws = Webservice(host=d["host"], port=d["port"])
     else:
-        ws = DummyWebservice()
+        return None
 
     def encode_address(v):
         if isinstance(v, bytes):
@@ -409,7 +409,7 @@ def main(ctx, config_path: str) -> None:
         + sender.services
         + watcher.services
         + confirmation_task_planner.services
-        + webservice.services
+        + (webservice.services if webservice is not None else [])
     )
 
     install_signal_handler(

--- a/tools/bridge/bridge/webservice.py
+++ b/tools/bridge/bridge/webservice.py
@@ -81,9 +81,3 @@ class Webservice:
         http_server = WSGIServer((self.host, self.port), self.app, log=logger)
         logger.info(f"Webservice is running on http://{self.host}:{self.port}".format())
         http_server.serve_forever()
-
-
-class DummyWebservice(Webservice):
-    def __init__(self, *, host, port):
-        super()(host=host, port=port)
-        self.services = []

--- a/tools/bridge/bridge/webservice.py
+++ b/tools/bridge/bridge/webservice.py
@@ -1,0 +1,89 @@
+import logging
+import os
+
+import falcon
+import pkg_resources
+from gevent.pywsgi import WSGIServer
+
+from bridge.service import Service
+
+logger = logging.getLogger(__name__)
+
+welcome_page = """
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>tlbc-bridge</title>
+</head>
+
+<body>
+<header>
+<h1>Welcome to tlbc-bridge</h1>
+</header>
+
+<p>
+You have reached tlbc-bridge's REST server. This is only meant for
+debugging.
+</p>
+
+<p>
+If you see this in a production setup, please remove the
+<code>[webservice]</code> section from your config file.
+</p>
+
+</body>
+</html>
+"""
+
+
+class WelcomePage:
+    def on_get(self, req, resp):
+        resp.body = welcome_page
+        resp.content_type = "text/html"
+
+
+class InternalState:
+    def __init__(self, *, recorder, public_config):
+        self.recorder = recorder
+        self.public_config = public_config
+
+    def on_get(self, req, resp):
+        resp.media = {
+            "bridge": {
+                "version": pkg_resources.get_distribution("tlbc-bridge").version,
+                "config": self.public_config,
+                "process": {
+                    "pid": os.getpid(),
+                    "uid": os.getuid(),
+                    "gid": os.getgid(),
+                    "loadavg": os.getloadavg(),
+                },
+                "recorder": self.recorder.get_state_summary(),
+            }
+        }
+
+
+class Webservice:
+    def __init__(self, *, host, port):
+        self.host = host
+        self.port = port
+
+        self.app = falcon.API()
+        self.app.add_route("/", WelcomePage())
+        self.services = [Service("webservice", self.run)]
+
+    def enable_internal_state(self, internal_state):
+        self.app.add_route("/bridge/internal-state", internal_state)
+
+    def run(self):
+        http_server = WSGIServer((self.host, self.port), self.app, log=logger)
+        logger.info(f"Webservice is running on http://{self.host}:{self.port}".format())
+        http_server.serve_forever()
+
+
+class DummyWebservice(Webservice):
+    def __init__(self, *, host, port):
+        super()(host=host, port=port)
+        self.services = []

--- a/tools/bridge/setup.cfg
+++ b/tools/bridge/setup.cfg
@@ -14,6 +14,7 @@ install_requires =
     validators>=0.13,<0.14
     tenacity>=5.1.1,<5.2
     setproctitle>=1.1.10,<1.2
+    falcon>=2.0.0,<2.1
 
 packages = bridge
 


### PR DESCRIPTION
This may prove useful for the end2end tests, see the discussion in
https://github.com/trustlines-protocol/blockchain/issues/358

It can be enabled by the following snippet:

  [webservice]
  enabled = true
  host = "127.0.0.1"
  port = 9500

The '/bridge/internal-state' endpoint provides information about the
internal state. It looks like the following:

,----
| % http http://localhost:9500/bridge/internal-state
| HTTP/1.1 200 OK
| Date: Wed, 28 Aug 2019 22:12:37 GMT
| content-length: 1058
| content-type: application/json
|
| {
|     "bridge": {
|         "config": {
|             "foreign_bridge_contract_address": "0xb4c79daB8f259C7Aee6E5b2Aa729821864227e84",
|             "foreign_chain_event_fetch_start_block_number": 0,
|             "foreign_chain_max_reorg_depth": 0,
|             "foreign_chain_token_contract_address": "0x731a10897d267e19B34503aD902d0A29173Ba4B1",
|             "foreign_rpc_url": "http://localhost:9200",
|             "home_bridge_contract_address": "0x771434486a221c6146F27B72fd160Bdf0eb1288e",
|             "home_chain_event_fetch_start_block_number": 3849548,
|             "home_chain_max_reorg_depth": 2,
|             "home_rpc_url": "http://localhost:9100"
|         },
|         "process": {
|             "gid": 1001,
|             "loadavg": [
|                 0.44,
|                 0.41,
|                 0.32
|             ],
|             "pid": 14478,
|             "uid": 1001
|         },
|         "recorder": {
|             "balance": "13286498470000000000",
|             "is-balance-sufficient": true,
|             "is-validating": true,
|             "is-validator": true,
|             "last-fetcher-reached-head-event": [
|                 {
|                     "chain-role": "foreign",
|                     "last-fetched-block-number": 5673,
|                     "timestamp": 1567030356.144592
|                 },
|                 {
|                     "chain-role": "home",
|                     "last-fetched-block-number": 3868357,
|                     "timestamp": 1567030356.4055734
|                 }
|             ],
|             "num-completions": 0,
|             "num-scheduled-hashes": 0,
|             "num-transfer-events": 0
|         },
|         "version": "0.1.0"
|     }
| }
`----

I've chosen the falcon framework (https://falconframework.org/)
instead of Flask. This looks much simpler and doesn't require any
magic, like thread local variables. Also, it has no dependencies. I
actually also considered bottle and pyramid.

The keys inside the response are kebab-cased (except those in the
config section, because they correspond to the config entries in the
TOML file). This was a deliberate decision. Please don't try to change
my mind.