### PR TITLE
Allow not having a webservice section in config file

### DIFF
--- a/tools/bridge/bridge/config.py
+++ b/tools/bridge/bridge/config.py
@@ -152,7 +152,7 @@ class ConfigSchema(Schema):
 
     validator_private_key = fields.Nested(PrivateKeySchema, required=True)
     logging = LoggingField(missing=lambda: dict(FORCED_LOGGING_CONFIG))
-    webservice = fields.Nested(WebserviceSchema)
+    webservice = fields.Nested(WebserviceSchema, missing=dict)
 
 
 config_schema = ConfigSchema()


### PR DESCRIPTION
While the contents of the webservice section in the config file is optional, this is not the case for the section itself. This is confusing. This PR fixes tihs.