### PR TITLE
Allow using quickstart script to setup non-validator node

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -19,7 +19,7 @@ services:
       - ${HOST_BASE_DIR:-.}/trustlines/config:/config/custom
       - ${HOST_BASE_DIR:-.}/trustlines/enode:/config/network
     command: >-
-      --role validator
+      --role ${ROLE}
       --address ${VALIDATOR_ADDRESS}
 
   mainnet-node:

--- a/tools/quickstart/quickstart/cli.py
+++ b/tools/quickstart/quickstart/cli.py
@@ -20,7 +20,7 @@ def main(host_base_dir):
         validator_account.setup_interactively()
         bridge.setup_interactively()
     netstats.setup_interactively()
-    docker.update_and_start(host_base_dir)
+    docker.update_and_start(host_base_dir, as_validator=setup_as_validator)
 
 
 def prompt_setup_as_validator():

--- a/tools/quickstart/quickstart/cli.py
+++ b/tools/quickstart/quickstart/cli.py
@@ -15,10 +15,26 @@ from quickstart import bridge, docker, netstats, validator_account
     default=os.getcwd(),
 )
 def main(host_base_dir):
-    validator_account.setup_interactively()
+    setup_as_validator = prompt_setup_as_validator()
+    if setup_as_validator:
+        validator_account.setup_interactively()
+        bridge.setup_interactively()
     netstats.setup_interactively()
-    bridge.setup_interactively()
     docker.update_and_start(host_base_dir)
+
+
+def prompt_setup_as_validator():
+    choice = click.prompt(
+        "Do you want to setup a validator (1) a regular node (2)?",
+        type=click.Choice(("1", "2")),
+        show_choices=False,
+    )
+    if choice == "1":
+        return True
+    elif choice == "2":
+        return False
+    else:
+        assert False, "unreachable"
 
 
 if __name__ == "__main__":

--- a/tools/quickstart/quickstart/docker.py
+++ b/tools/quickstart/quickstart/docker.py
@@ -38,6 +38,7 @@ def update_and_start(host_base_dir: str, as_validator: bool) -> None:
     else:
         docker_environment_variables = {
             **base_docker_environment_variables,
+            "VALIDATOR_ADDRESS": "",
             "ROLE": "observer",
         }
 

--- a/tools/quickstart/quickstart/docker.py
+++ b/tools/quickstart/quickstart/docker.py
@@ -12,11 +12,7 @@ from quickstart.utils import (
 from quickstart.validator_account import get_validator_address
 
 
-def update_and_start(host_base_dir: str) -> None:
-    if not is_validator_account_prepared():
-        raise click.ClickException(
-            "Can not start docker services without having set up a validator account!"
-        )
+def update_and_start(host_base_dir: str, as_validator: bool) -> None:
 
     if not os.path.isfile("docker-compose.yaml") and not os.path.isfile(
         "docker-compose.yml"
@@ -27,11 +23,23 @@ def update_and_start(host_base_dir: str) -> None:
         )
 
     docker_service_names = get_docker_service_names()
-    docker_environment_variables = {
-        **os.environ,
-        "HOST_BASE_DIR": host_base_dir,
-        "VALIDATOR_ADDRESS": get_validator_address(),
-    }
+    base_docker_environment_variables = {**os.environ, "HOST_BASE_DIR": host_base_dir}
+
+    if as_validator:
+        if not is_validator_account_prepared():
+            raise click.ClickException(
+                "Can not start docker services as validator without having set up a validator account!"
+            )
+        docker_environment_variables = {
+            **base_docker_environment_variables,
+            "VALIDATOR_ADDRESS": get_validator_address(),
+            "ROLE": "validator",
+        }
+    else:
+        docker_environment_variables = {
+            **base_docker_environment_variables,
+            "ROLE": "observer",
+        }
 
     try:
         click.echo("\nShutting down possibly remaining docker services...")


### PR DESCRIPTION
Closes #391 

Haven't fully tested it yet as I need to install docker first.

What confused me a little is that at the moment `/config/user-config.yaml` appears to be used instead of `/config/validator-config.toml`. That's actually what we'd want for this PR, but not for the normal case. I'll check if this is true or if I'm misreading the code when I've setup docker to test this PR.