### PR TITLE
Stop containers started by the old quickstart script

### DIFF
--- a/tools/quickstart/Dockerfile
+++ b/tools/quickstart/Dockerfile
@@ -33,6 +33,11 @@ COPY tools/quickstart /src/
 COPY tools/quickstart/constraints.txt /src/
 RUN pip install -c constraints.txt .
 
+# get docker as standalone binary
+RUN curl -L https://download.docker.com/`uname -s | awk '{print tolower($0)}'`/static/stable/`uname -m`/docker-19.03.2.tgz --output /tmp/docker.tgz &&  \
+    tar -xf /tmp/docker.tgz -C /tmp/ &&  \
+    mv /tmp/docker/docker /opt/quickstart/bin/docker &&  \
+    chmod +x /opt/quickstart/bin/docker
 # get docker-compose as standalone binary
 RUN curl -L https://github.com/docker/compose/releases/download/1.24.1/docker-compose-`uname -s`-`uname -m` \
     -o /opt/quickstart/bin/docker-compose && \

--- a/tools/quickstart/quickstart/docker.py
+++ b/tools/quickstart/quickstart/docker.py
@@ -11,6 +11,10 @@ from quickstart.utils import (
 )
 from quickstart.validator_account import get_validator_address
 
+# List of docker container names to stop and remove on startup in addition to the ones defined in
+# the docker compose file (for backward compatibility)
+LEGACY_CONTAINER_NAMES = ["watchtower-testnet", "trustlines-testnet"]
+
 
 def update_and_start(host_base_dir: str) -> None:
     if not is_validator_account_prepared():
@@ -36,6 +40,13 @@ def update_and_start(host_base_dir: str) -> None:
     try:
         click.echo("\nShutting down possibly remaining docker services...")
         subprocess.run(["docker-compose", "down"], env=docker_environment_variables)
+        for container_name in LEGACY_CONTAINER_NAMES:
+            subprocess.run(
+                ["docker", "stop", container_name], env=docker_environment_variables
+            )
+            subprocess.run(
+                ["docker", "rm", container_name], env=docker_environment_variables
+            )
 
         click.echo("\nPulling recent Docker image versions...")
         subprocess.run(


### PR DESCRIPTION
See bullet point 2 in #385

I didn't manage to do this without adding docker itself to the quickstart script container. Using `docker-compose` to stop the containers doesn't work (it doesn't find them -- maybe because they are not defined in the docker-compose file) and `docker` itself appears to be available, but when run crashes due to a missing `libltdl.so` file