### PR TITLE
[Do not merge] Demonstrate problematic behaviour of .call.value(..).gas(...)("")

### DIFF
--- a/contracts/contracts/bridge/TestTransfer.sol
+++ b/contracts/contracts/bridge/TestTransfer.sol
@@ -1,0 +1,18 @@
+pragma solidity ^0.5.8;
+
+contract TestRecipient {
+    uint public numCalls;
+    function() external payable {
+        numCalls += 1;
+    }
+}
+
+contract TestTransfer {
+    function() external payable {}
+
+    function doit(address payable recipient) public returns (bool) {
+        /* solium-disable-next-line */
+        (bool res, ) = recipient.call.value(1).gas(80000)("");
+        return res;
+    }
+}

--- a/contracts/tests/bridge/test_transfer.py
+++ b/contracts/tests/bridge/test_transfer.py
@@ -1,0 +1,46 @@
+import pytest
+
+
+@pytest.fixture()
+def test_recipient_contract(deploy_contract):
+    return deploy_contract("TestRecipient", constructor_args=())
+
+
+@pytest.fixture()
+def recipient(test_recipient_contract):
+    return test_recipient_contract.address
+
+
+@pytest.fixture()
+def test_transfer_contract(deploy_contract, web3, accounts):
+
+    contract = deploy_contract("TestTransfer", constructor_args=())
+
+    account_0 = accounts[0]
+
+    web3.eth.sendTransaction(
+        {
+            "from": account_0,
+            "to": contract.address,
+            "gas": 100_000,
+            "value": 5 * 10 ** 18,
+        }
+    )
+
+    return contract
+
+
+@pytest.mark.parametrize("gas", [200_000, 50_700, 30_000])
+def test_transfer(test_transfer_contract, accounts, web3, recipient, gas):
+    tx_hash = test_transfer_contract.functions.doit(recipient).transact({"gas": gas})
+    tx_receipt = web3.eth.getTransactionReceipt(tx_hash)
+
+    balance = web3.eth.getBalance(recipient)
+
+    print(
+        f"gas: {gas} status: {tx_receipt.status} gas used: {tx_receipt.gasUsed} balance: {balance}"
+    )
+
+    assert (
+        tx_receipt.status != 1 or balance == 1
+    ), "tx succeded but internal transfer failed"


### PR DESCRIPTION
Here we have a test that shows a transfer being done or not based on
the amount of gas the caller has provided even though the transaction
succeeeds.

Please note that 'recipient.call.value(1).gas(80000)("")' does not
revert even though we do not have enough gas.

See https://github.com/trustlines-protocol/blockchain/issues/392