### PR TITLE
Measure gas usage on validator set changes, increase gas

### DIFF
--- a/tools/bridge/bridge/constants.py
+++ b/tools/bridge/bridge/constants.py
@@ -5,10 +5,10 @@ CONFIRMATION_EVENT_NAME = "Confirmation"
 COMPLETION_EVENT_NAME = "TransferCompleted"
 
 # Gas limit used for confirmation transactions. The actual gas usage can be determined with
-# test_measure_gas_home_bridge.py found in the smart contract test directory. As of commit
-# cc46ea961ece850ce28a2d62b7c484f8fa82ca3c, this is 321004, but we add a generous safety margin.
+# test_measure_gas_home_bridge.py found in the smart contract test directory. Currently this is
+# 422074, but we add a generous safety margin.
 # On changing this value, update the corresponding constant in the test script accordingly.
-CONFIRMATION_TRANSACTION_GAS_LIMIT = 400_000
+CONFIRMATION_TRANSACTION_GAS_LIMIT = 500_000
 
 # maximum amount of time in seconds application greenlets have to cleanup before shutdown
 APPLICATION_CLEANUP_TIMEOUT = 5


### PR DESCRIPTION
Add a test that measures gas usage on validator set changes. We have a
case that needs around 422k gas.

Increase the CONFIRMATION_TRANSACTION_GAS_LIMIT from 400k to 500k.