### PR TITLE
Reconfirm completes transfer

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
     - id: end-of-file-fixer
       exclude: ^contracts/contracts/lib/.*\.sol|contracts/contracts/token/TrustlinesNetworkToken.sol$
     - id: flake8
-      additional_dependencies: ["flake8-string-format", "flake8-per-file-ignores"]
+      additional_dependencies: ["flake8-string-format", "pep8-naming"]
     - id: trailing-whitespace
       exclude: ^contracts/contracts/lib/.*\.sol$
     - id: no-commit-to-branch

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,10 @@
 black
-flake8
 mypy
-pep8-naming
 pre-commit
 pytest
 setuptools_scm
+
+# flake8 and plugins, keep them in sync with pre-commit's config
+flake8
+pep8-naming
+flake8-string-format

--- a/tools/bridge/bridge/constants.py
+++ b/tools/bridge/bridge/constants.py
@@ -5,10 +5,10 @@ CONFIRMATION_EVENT_NAME = "Confirmation"
 COMPLETION_EVENT_NAME = "TransferCompleted"
 
 # Gas limit used for confirmation transactions. The actual gas usage can be determined with
-# test_measure_gas_home_bridge.py found in the smart contract test directory. As of commit
-# cc46ea961ece850ce28a2d62b7c484f8fa82ca3c, this is 321004, but we add a generous safety margin.
+# test_measure_gas_home_bridge.py found in the smart contract test directory. Currently this is
+# 422074, but we add a generous safety margin.
 # On changing this value, update the corresponding constant in the test script accordingly.
-CONFIRMATION_TRANSACTION_GAS_LIMIT = 400_000
+CONFIRMATION_TRANSACTION_GAS_LIMIT = 500_000
 
 # maximum amount of time in seconds application greenlets have to cleanup before shutdown
 APPLICATION_CLEANUP_TIMEOUT = 5


### PR DESCRIPTION
This is based on PR #404, please only review the last two commits.

Add reconfirmCompletesTransfer view

This view can be used by the validators to check if calling
confirmTransfer a second time would complete the transfer. This makes
sense after validator set changes.
