### PR TITLE
Minor quickstart improvements

### DIFF
--- a/quickstart.sh
+++ b/quickstart.sh
@@ -52,7 +52,7 @@ Hint:
 You can create the group 'docker' and add your current user with the following
 commands.
 
-$ sudo goupadd docker
+$ sudo groupadd docker
 $ sudo usermod -a -G docker $USER
 
 EOF

--- a/tools/quickstart/quickstart/bridge.py
+++ b/tools/quickstart/quickstart/bridge.py
@@ -18,12 +18,15 @@ from quickstart.constants import (
     BRIDGE_CONFIG_KEYSTORE_PATH,
     BRIDGE_DOCUMENTATION_URL,
 )
-from quickstart.utils import is_bridge_prepared
+from quickstart.utils import is_bridge_prepared, is_validator_account_prepared
 
 
 def setup_interactively() -> None:
     if is_bridge_prepared():
         click.echo("You have already set up the bridge client.\n")
+        return
+    if not is_validator_account_prepared():
+        click.echo("Not setting up a bridge node as running as a non-validator.\n")
         return
 
     click.echo(

--- a/tools/quickstart/quickstart/bridge.py
+++ b/tools/quickstart/quickstart/bridge.py
@@ -23,31 +23,26 @@ from quickstart.utils import is_bridge_prepared, is_validator_account_prepared
 
 def setup_interactively() -> None:
     if is_bridge_prepared():
-        click.echo("You have already set up the bridge client.\n")
+        click.echo("The bridge client has already been set up.\n")
         return
     if not is_validator_account_prepared():
-        click.echo("Not setting up a bridge node as running as a non-validator.\n")
+        click.echo("No bridge node will be set up as running as a non-validator.\n")
         return
 
     click.echo(
         "\n".join(
             (
-                "",
                 fill(
-                    "As a validator, you are required to run the bridge as well. We can set "
-                    "everything up or you do it yourself later. A setup requires an additional "
-                    "node syncing the Ethereum mainnet. This node will run in light mode to use "
-                    "as little resources as possible. Checkout the following link for more "
-                    "information on how the bridge works:"
+                    "As a validator of the Trustlines blockchain, you are required to run a "
+                    "bridge node. Checkout the following link for more information:"
                 ),
                 BRIDGE_DOCUMENTATION_URL,
-                "This setup will reuse the keystore of the validator node.",
                 "",
             )
         )
     )
     if not click.confirm(
-        "Do you want to set the bridge client up? (highly recommended)", default=True
+        "Do you want to set up a bridge node now? (recommended)", default=True
     ):
         # Necessary to make docker-compose not complain about it.
         Path(BRIDGE_CONFIG_FILE_EXTERNAL).touch()
@@ -68,7 +63,7 @@ def setup_interactively() -> None:
     with open(BRIDGE_CONFIG_FILE_EXTERNAL, "w") as config_file:
         toml.dump(configuration, config_file)
 
-    click.echo("Bridge client setup complete.\n")
+    click.echo("Bridge client setup complete.")
 
 
 def get_bridge_configuration(

--- a/tools/quickstart/quickstart/bridge.py
+++ b/tools/quickstart/quickstart/bridge.py
@@ -68,7 +68,7 @@ def setup_interactively() -> None:
     with open(BRIDGE_CONFIG_FILE_EXTERNAL, "w") as config_file:
         toml.dump(configuration, config_file)
 
-    click.echo("Bridge client setup complete.")
+    click.echo("Bridge client setup complete.\n")
 
 
 def get_bridge_configuration(

--- a/tools/quickstart/quickstart/bridge.py
+++ b/tools/quickstart/quickstart/bridge.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from textwrap import fill
 from typing import Dict
 
 import click
@@ -26,12 +27,21 @@ def setup_interactively() -> None:
         return
 
     click.echo(
-        "\nAs a validator, you are required to run the bridge as well. We can set "
-        "everything up or you do it yourself later. A setup requires an additional "
-        "node syncing the Ethereum mainnet. This node will run in light mode to use "
-        "as little resources as possible. Checkout the following link for more "
-        f"information on how the bridge works:\n{BRIDGE_DOCUMENTATION_URL}\nThis "
-        "setup will reuse the keystore of the validator node.\n"
+        "\n".join(
+            (
+                "",
+                fill(
+                    "As a validator, you are required to run the bridge as well. We can set "
+                    "everything up or you do it yourself later. A setup requires an additional "
+                    "node syncing the Ethereum mainnet. This node will run in light mode to use "
+                    "as little resources as possible. Checkout the following link for more "
+                    "information on how the bridge works:"
+                ),
+                BRIDGE_DOCUMENTATION_URL,
+                "This setup will reuse the keystore of the validator node.",
+                "",
+            )
+        )
     )
     if not click.confirm(
         "Do you want to set the bridge client up? (highly recommended)", default=True

--- a/tools/quickstart/quickstart/cli.py
+++ b/tools/quickstart/quickstart/cli.py
@@ -9,8 +9,8 @@ from quickstart import bridge, docker, netstats, validator_account
 @click.option(
     "--host-base-dir",
     help=(
-        "absolute path to use for docker volumes "
-        "(only relevant when run from inside a docker container itself)"
+        "absolute path to use for docker volumes (only relevant when run from inside a docker "
+        "container itself)"
     ),
     default=os.getcwd(),
 )

--- a/tools/quickstart/quickstart/cli.py
+++ b/tools/quickstart/quickstart/cli.py
@@ -1,4 +1,5 @@
 import os
+from textwrap import fill
 
 import click
 
@@ -15,6 +16,26 @@ from quickstart import bridge, docker, netstats, validator_account
     default=os.getcwd(),
 )
 def main(host_base_dir):
+    click.echo()
+    click.echo(
+        "\n".join(
+            (
+                fill(
+                    "This script will guide you through the setup of a Laika testnet node as well as a few "
+                    "additional services. Once it is complete, the components will run in the background as "
+                    "docker containers."
+                ),
+                "",
+                fill(
+                    "It is safe to run this script multiple times. Already existing containers will be "
+                    "restarted and no configuration will be overwritten. It is possible to enable "
+                    "additional components that you have chosen not to configure in earlier runs."
+                ),
+                "",
+            )
+        )
+    )
+
     validator_account.setup_interactively()
     bridge.setup_interactively()
     netstats.setup_interactively()

--- a/tools/quickstart/quickstart/cli.py
+++ b/tools/quickstart/quickstart/cli.py
@@ -15,26 +15,10 @@ from quickstart import bridge, docker, netstats, validator_account
     default=os.getcwd(),
 )
 def main(host_base_dir):
-    setup_as_validator = prompt_setup_as_validator()
-    if setup_as_validator:
-        validator_account.setup_interactively()
-        bridge.setup_interactively()
+    validator_account.setup_interactively()
+    bridge.setup_interactively()
     netstats.setup_interactively()
-    docker.update_and_start(host_base_dir, as_validator=setup_as_validator)
-
-
-def prompt_setup_as_validator():
-    choice = click.prompt(
-        "Do you want to setup a validator (1) a regular node (2)?",
-        type=click.Choice(("1", "2")),
-        show_choices=False,
-    )
-    if choice == "1":
-        return True
-    elif choice == "2":
-        return False
-    else:
-        assert False, "unreachable"
+    docker.update_and_start(host_base_dir)
 
 
 if __name__ == "__main__":

--- a/tools/quickstart/quickstart/docker.py
+++ b/tools/quickstart/quickstart/docker.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+from textwrap import fill
 from typing import List
 
 import click
@@ -22,8 +23,10 @@ def update_and_start(host_base_dir: str, as_validator: bool) -> None:
         "docker-compose.yml"
     ):
         raise click.ClickException(
-            "Expecting a docker-compose configuration file at the current directory "
-            "with a standard name. ('docker-compose.yaml' or 'docker-compose.yml')"
+            fill(
+                "Expecting a docker-compose configuration file at the current directory "
+                "with a standard name. ('docker-compose.yaml' or 'docker-compose.yml')"
+            )
         )
 
     docker_service_names = get_docker_service_names()
@@ -32,7 +35,10 @@ def update_and_start(host_base_dir: str, as_validator: bool) -> None:
     if as_validator:
         if not is_validator_account_prepared():
             raise click.ClickException(
-                "Can not start docker services as validator without having set up a validator account!"
+                fill(
+                    "Can not start docker services as validator without having set up a "
+                    "validator account!"
+                )
             )
         docker_environment_variables = {
             **base_docker_environment_variables,

--- a/tools/quickstart/quickstart/docker.py
+++ b/tools/quickstart/quickstart/docker.py
@@ -44,39 +44,43 @@ def update_and_start(host_base_dir: str) -> None:
             "ROLE": "observer",
         }
 
+    run_kwargs = {
+        "env": docker_environment_variables,
+        "stdout": subprocess.DEVNULL,
+        "stderr": subprocess.DEVNULL,
+    }
+
     try:
         click.echo("\nShutting down possibly remaining docker services...")
-        subprocess.run(["docker-compose", "down"], env=docker_environment_variables)
+        subprocess.run(["docker-compose", "down"], check=True, **run_kwargs)
         for container_name in LEGACY_CONTAINER_NAMES:
+            # use check=False as docker stop and docker rm fail if the container does not exist
             subprocess.run(
-                ["docker", "stop", container_name], env=docker_environment_variables
+                ["docker", "stop", container_name], check=False, **run_kwargs
             )
-            subprocess.run(
-                ["docker", "rm", container_name], env=docker_environment_variables
-            )
+            subprocess.run(["docker", "rm", container_name], check=False, **run_kwargs)
 
         click.echo("\nPulling recent Docker image versions...")
         subprocess.run(
-            ["docker-compose", "pull"] + docker_service_names,
-            env=docker_environment_variables,
-            check=True,
+            ["docker-compose", "pull"] + docker_service_names, check=True, **run_kwargs
         )
 
         click.echo("\nStarting Docker services...")
+        subprocess.run(["docker-compose", "up", "--no-start"], check=True, **run_kwargs)
         subprocess.run(
-            ["docker-compose", "up", "--no-start"],
-            env=docker_environment_variables,
-            check=True,
-        )
-        subprocess.run(
-            ["docker-compose", "start"] + docker_service_names,
-            env=docker_environment_variables,
-            check=True,
+            ["docker-compose", "start"] + docker_service_names, check=True, **run_kwargs
         )
 
-    except subprocess.CalledProcessError:
+    except subprocess.CalledProcessError as called_process_error:
         raise click.ClickException(
-            "Something went wrong while interacting with Docker."
+            "\n".join(
+                (
+                    fill(
+                        f"Command {' '.join(called_process_error.cmd)} failed with exit code "
+                        f"{called_process_error.returncode}."
+                    ),
+                )
+            )
         )
 
     click.echo("\nAll services are running. Congratulations!")

--- a/tools/quickstart/quickstart/docker.py
+++ b/tools/quickstart/quickstart/docker.py
@@ -17,8 +17,7 @@ from quickstart.validator_account import get_validator_address
 LEGACY_CONTAINER_NAMES = ["watchtower-testnet", "trustlines-testnet"]
 
 
-def update_and_start(host_base_dir: str, as_validator: bool) -> None:
-
+def update_and_start(host_base_dir: str) -> None:
     if not os.path.isfile("docker-compose.yaml") and not os.path.isfile(
         "docker-compose.yml"
     ):
@@ -32,14 +31,7 @@ def update_and_start(host_base_dir: str, as_validator: bool) -> None:
     docker_service_names = get_docker_service_names()
     base_docker_environment_variables = {**os.environ, "HOST_BASE_DIR": host_base_dir}
 
-    if as_validator:
-        if not is_validator_account_prepared():
-            raise click.ClickException(
-                fill(
-                    "Can not start docker services as validator without having set up a "
-                    "validator account!"
-                )
-            )
+    if is_validator_account_prepared():
         docker_environment_variables = {
             **base_docker_environment_variables,
             "VALIDATOR_ADDRESS": get_validator_address(),

--- a/tools/quickstart/quickstart/docker.py
+++ b/tools/quickstart/quickstart/docker.py
@@ -37,12 +37,14 @@ def update_and_start(host_base_dir: str) -> None:
             "VALIDATOR_ADDRESS": get_validator_address(),
             "ROLE": "validator",
         }
+        click.echo("\nNode will run as a validator")
     else:
         docker_environment_variables = {
             **base_docker_environment_variables,
             "VALIDATOR_ADDRESS": "",
             "ROLE": "observer",
         }
+        click.echo("\nNode will run as a non-validator")
 
     run_kwargs = {
         "env": docker_environment_variables,
@@ -51,7 +53,7 @@ def update_and_start(host_base_dir: str) -> None:
     }
 
     try:
-        click.echo("\nShutting down possibly remaining docker services...")
+        click.echo("Shutting down possibly remaining docker services first...")
         subprocess.run(["docker-compose", "down"], check=True, **run_kwargs)
         for container_name in LEGACY_CONTAINER_NAMES:
             # use check=False as docker stop and docker rm fail if the container does not exist
@@ -60,12 +62,12 @@ def update_and_start(host_base_dir: str) -> None:
             )
             subprocess.run(["docker", "rm", container_name], check=False, **run_kwargs)
 
-        click.echo("\nPulling recent Docker image versions...")
+        click.echo("Pulling recent Docker image versions...")
         subprocess.run(
             ["docker-compose", "pull"] + docker_service_names, check=True, **run_kwargs
         )
 
-        click.echo("\nStarting Docker services...")
+        click.echo("Starting Docker services...")
         subprocess.run(["docker-compose", "up", "--no-start"], check=True, **run_kwargs)
         subprocess.run(
             ["docker-compose", "start"] + docker_service_names, check=True, **run_kwargs

--- a/tools/quickstart/quickstart/netstats.py
+++ b/tools/quickstart/quickstart/netstats.py
@@ -17,19 +17,26 @@ INSTANCE_NAME={instance_name}
 
 def setup_interactively() -> None:
     if is_netstats_prepared():
-        click.echo("You have already set up the netstats client.\n")
+        click.echo("\nThe netstats client has already been set up.\n")
         return
 
     click.echo(
         "\n".join(
             (
-                "We can set up a client that reports to the netstats server running at",
+                "",
+                fill(
+                    "This script can set up a client that reports to the netstats server running at"
+                ),
                 NETSTATS_SERVER_BASE_URL,
                 "This helps the community to observe the state of the network.",
                 "",
-                "You will need credentials to do that. Write a mail to",
+                fill(
+                    "You will need credentials to do that. Please feel free to send an email to"
+                ),
                 "'netstats@trustlines.foundation'",
-                "to receive some.",
+                fill(
+                    "to receive yours if you don't have any yet and would like to participate."
+                ),
                 "",
             )
         )
@@ -37,7 +44,7 @@ def setup_interactively() -> None:
 
     if not click.confirm(
         fill(
-            "Have you already received credentials and do you want to set the netstats client up?"
+            "Have you already received credentials and do you want to set up the netstats client?"
         )
     ):
         # Necessary to make docker-compose not complaining about it.
@@ -58,7 +65,9 @@ def setup_interactively() -> None:
                 + "\n".join(
                     (
                         "The provided credentials could not be verified.",
-                        "Please try entering them and make sure you are connected to the internet.",
+                        fill(
+                            "Please try entering them and make sure you are connected to the internet."
+                        ),
                     )
                 )
             )
@@ -67,7 +76,9 @@ def setup_interactively() -> None:
         "\n".join(
             (
                 "Please enter a name to identify your instance on the website.",
-                "You are free to choose any name you like. Note that the name will be publicly visible.",
+                fill(
+                    "You are free to choose any name you like. Note that the name will be publicly visible."
+                ),
             )
         )
     )

--- a/tools/quickstart/quickstart/netstats.py
+++ b/tools/quickstart/quickstart/netstats.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from textwrap import fill
 
 import click
 import requests
@@ -20,15 +21,24 @@ def setup_interactively() -> None:
         return
 
     click.echo(
-        "\nWe can set up a client that reports to the netstats server running at\n"
-        f"{NETSTATS_SERVER_BASE_URL}\nThis helps the community to observe the state of "
-        "the network.\n\nYou will need credentials to do that. Write a mail to \n"
-        "'netstats@trustlines.foundation'\nto receive some.\n"
+        "\n".join(
+            (
+                "We can set up a client that reports to the netstats server running at",
+                NETSTATS_SERVER_BASE_URL,
+                "This helps the community to observe the state of the network.",
+                "",
+                "You will need credentials to do that. Write a mail to",
+                "'netstats@trustlines.foundation'",
+                "to receive some.",
+                "",
+            )
+        )
     )
 
     if not click.confirm(
-        "Have you already received credentials and "
-        "do you want to set the netstats client up?"
+        fill(
+            "Have you already received credentials and do you want to set the netstats client up?"
+        )
     ):
         # Necessary to make docker-compose not complaining about it.
         Path(NETSTATS_ENV_FILE_PATH).touch()
@@ -44,13 +54,22 @@ def setup_interactively() -> None:
 
         else:
             click.echo(
-                "The provided credentials could not be verified.\nPlease try entering "
-                "them and make sure you are connected to the internet."
+                "\n"
+                + "\n".join(
+                    (
+                        "The provided credentials could not be verified.",
+                        "Please try entering them and make sure you are connected to the internet.",
+                    )
+                )
             )
 
     click.echo(
-        "Please enter a name to identify your instance on the website.\nYou are free "
-        "to choose any name you like. Note that the name will be publicly visible."
+        "\n".join(
+            (
+                "Please enter a name to identify your instance on the website.",
+                "You are free to choose any name you like. Note that the name will be publicly visible.",
+            )
+        )
     )
 
     instance_name = click.prompt("Instance name")

--- a/tools/quickstart/quickstart/utils.py
+++ b/tools/quickstart/quickstart/utils.py
@@ -3,6 +3,7 @@ import os
 import re
 import sys
 from pathlib import Path
+from textwrap import fill
 from typing import Tuple
 
 import click
@@ -20,14 +21,22 @@ from quickstart.constants import (
 def ensure_clean_setup():
     if os.path.isdir(KEY_DIR):
         raise click.ClickException(
-            "The directory holding the keys already exists.\n"
-            "This should not occur during normal operation."
+            "\n".join(
+                (
+                    "The directory holding the keys already exists.",
+                    "This should not occur during normal operation.",
+                )
+            )
         )
 
     if os.path.isfile(PASSWORD_FILE_PATH):
         raise click.ClickException(
-            "The password file already exists.\n"
-            "This should not occur during normal operation."
+            "\n".join(
+                (
+                    "The password file already exists.",
+                    "This should not occur during normal operation.",
+                )
+            )
         )
 
 
@@ -80,11 +89,17 @@ def is_wrong_password_error(err):
 
 def get_keystore_path() -> str:
     click.echo(
-        "Please enter the path to the keystore file to import.\nIf you started the "
-        "process via the quickstart scipt, please consider that you are running "
-        "within a Docker virtual file system. You can access the current working "
-        "directory via '/data'. (e.g. './my-dir/keystore.json' becomes "
-        "'/data/my-dir/keystore.json')"
+        "\n".join(
+            (
+                "Please enter the path to the keystore file to import.",
+                fill(
+                    "If you started the process via the quickstart scipt, please consider that you "
+                    "are running within a Docker virtual file system. You can access the current "
+                    "working directory via '/data'. (e.g. './my-dir/keystore.json' becomes "
+                    "'/data/my-dir/keystore.json')"
+                ),
+            )
+        )
     )
 
     while True:
@@ -96,8 +111,10 @@ def get_keystore_path() -> str:
 
         else:
             click.echo(
-                "The given path does not exist or is not readable. "
-                "Please try entering it again."
+                fill(
+                    "The given path does not exist or is not readable. Please try entering it "
+                    "again."
+                )
             )
 
 
@@ -111,7 +128,9 @@ def read_private_key() -> str:
             return private_key
 
         click.echo(
-            "The private key must be entered as a hex encoded string. Please try again."
+            fill(
+                "The private key must be entered as a hex encoded string. Please try again."
+            )
         )
 
 
@@ -142,5 +161,5 @@ def read_decryption_password(keyfile_dict) -> Tuple[Account, str]:
             if is_wrong_password_error(err):
                 click.echo("The password you entered is wrong. Please try again.")
             else:
-                click.echo(f"Error: failed to decrypt keystore file: {repr(err)}")
+                click.echo(fill(f"Error: failed to decrypt keystore file: {repr(err)}"))
                 sys.exit(1)

--- a/tools/quickstart/quickstart/utils.py
+++ b/tools/quickstart/quickstart/utils.py
@@ -12,28 +12,36 @@ from eth_account import Account
 from quickstart.constants import (
     ADDRESS_FILE_PATH,
     BRIDGE_CONFIG_FILE_EXTERNAL,
-    KEY_DIR,
+    KEYSTORE_FILE_PATH,
     NETSTATS_ENV_FILE_PATH,
     PASSWORD_FILE_PATH,
 )
 
 
 def ensure_clean_setup():
-    if os.path.isdir(KEY_DIR):
-        raise click.ClickException(
-            "\n".join(
-                (
-                    "The directory holding the keys already exists.",
-                    "This should not occur during normal operation.",
-                )
-            )
-        )
-
     if os.path.isfile(PASSWORD_FILE_PATH):
         raise click.ClickException(
             "\n".join(
                 (
                     "The password file already exists.",
+                    "This should not occur during normal operation.",
+                )
+            )
+        )
+    if os.path.isfile(KEYSTORE_FILE_PATH):
+        raise click.ClickException(
+            "\n".join(
+                (
+                    "The keystore file already exists.",
+                    "This should not occur during normal operation.",
+                )
+            )
+        )
+    if os.path.isfile(ADDRESS_FILE_PATH):
+        raise click.ClickException(
+            "\n".join(
+                (
+                    "The keystore file already exists.",
                     "This should not occur during normal operation.",
                 )
             )

--- a/tools/quickstart/quickstart/utils.py
+++ b/tools/quickstart/quickstart/utils.py
@@ -81,13 +81,13 @@ class TrustlinesFiles:
         json_account = account.encrypt(password, kdf="pbkdf2")
 
         os.makedirs(os.path.dirname(os.path.abspath(self.keystore_path)), exist_ok=True)
-        with open(self.keystore_path, "w") as f:
+        with open(self.keystore_path, "x") as f:
             f.write(json.dumps(json_account))
 
-        with open(self.password_path, "w") as f:
+        with open(self.password_path, "x") as f:
             f.write(password)
 
-        with open(self.address_path, "w") as f:
+        with open(self.address_path, "x") as f:
             f.write(account.address)
 
 

--- a/tools/quickstart/quickstart/validator_account.py
+++ b/tools/quickstart/quickstart/validator_account.py
@@ -28,6 +28,9 @@ def setup_interactively() -> None:
     if is_validator_account_prepared():
         click.echo("You have already set a validator node up.\n")
         return
+    if not prompt_setup_as_validator():
+        click.echo("Setting up a non-validator node.\n")
+        return
 
     ensure_clean_setup()
 
@@ -63,6 +66,20 @@ def setup_interactively() -> None:
         )
 
     click.echo("Validator account setup complete.")
+
+
+def prompt_setup_as_validator():
+    choice = click.prompt(
+        "Do you want to setup a validator (1) a regular node (2)?",
+        type=click.Choice(("1", "2")),
+        show_choices=False,
+    )
+    if choice == "1":
+        return True
+    elif choice == "2":
+        return False
+    else:
+        assert False, "unreachable"
 
 
 def import_keystore_file() -> None:

--- a/tools/quickstart/quickstart/validator_account.py
+++ b/tools/quickstart/quickstart/validator_account.py
@@ -26,15 +26,13 @@ from quickstart.utils import (
 
 def setup_interactively() -> None:
     if is_validator_account_prepared():
-        click.echo("You have already set a validator node up.\n")
+        click.echo("A validator account has already been set up.\n")
         return
     if not prompt_setup_as_validator():
-        click.echo("Setting up a non-validator node.\n")
+        click.echo("\n")
         return
 
     ensure_clean_setup()
-
-    click.echo("This script will setup a validator node for the Laika testnet chain.\n")
 
     os.makedirs(CONFIG_DIR, exist_ok=True)
     os.makedirs(ENODE_DIR, exist_ok=True)
@@ -65,12 +63,12 @@ def setup_interactively() -> None:
             )
         )
 
-    click.echo("Validator account setup complete.")
+    click.echo("Validator account setup complete.\n")
 
 
 def prompt_setup_as_validator():
     choice = click.prompt(
-        "Do you want to setup a validator (1) a regular node (2)?",
+        "Do you want to set up a validator account (1) or run a regular node (2)?",
         type=click.Choice(("1", "2")),
         show_choices=False,
     )

--- a/tools/quickstart/quickstart/validator_account.py
+++ b/tools/quickstart/quickstart/validator_account.py
@@ -1,5 +1,6 @@
 import json
 import os
+from textwrap import fill
 
 import click
 from eth_account import Account
@@ -37,8 +38,11 @@ def setup_interactively() -> None:
     os.makedirs(DATABASE_DIR, exist_ok=True)
 
     click.echo(
-        "Validators need a private key. This script can either import an existing JSON "
-        "keystore, import an existing raw private key, or it can create a new key.\n"
+        fill(
+            "Validators need a private key. This script can either import an existing JSON "
+            "keystore, import an existing raw private key, or it can create a new key."
+        )
+        + "\n"
     )
 
     if click.confirm("Do you want to import an existing keystore?"):
@@ -52,8 +56,10 @@ def setup_interactively() -> None:
 
     else:
         raise click.ClickException(
-            "To setup a validator node, a private key is required. "
-            "You need to select one of the previous options."
+            fill(
+                "To setup a validator node, a private key is required. You need to select one of "
+                "the previous options."
+            )
         )
 
     click.echo("Validator account setup complete.")


### PR DESCRIPTION
- some changes to the text and user flow
- limit line width using `textwrap.fill`
- open password, keystore, and address files with "x" for writing so that we don't accidentally overwrite something
- don't check for existence of key directory, but rather password/keystore/address files in `ensure_clean_setup` so that restarts work
- hide stdout/stderr of docker output

Closes #398 

Only thing from the issue I didn't do is colored output. I'm not sure what to color and since the docker output is gone I don't think it's still required.