### PR TITLE
Add monitor to quickstart script

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -20,7 +20,7 @@ services:
       - ${HOST_BASE_DIR:-.}/trustlines/databases:/data
       - ${HOST_BASE_DIR:-.}/trustlines/config:/config/custom
       - ${HOST_BASE_DIR:-.}/trustlines/enode:/config/network
-      - ${HOST_BASE_DIR:-.}/trustlines/shared-config:/config/chain-spec
+      - ${HOST_BASE_DIR:-.}/trustlines/shared:/shared/
     command: >-
       --role ${ROLE}
       --address ${VALIDATOR_ADDRESS}
@@ -97,10 +97,10 @@ services:
     volumes:
       - ${HOST_BASE_DIR:-.}/trustlines/monitor/reports:/reports
       - ${HOST_BASE_DIR:-.}/trustlines/monitor/state:/state
-      - ${HOST_BASE_DIR:-.}/trustlines/shared-config:/config/chain-spec
+      - ${HOST_BASE_DIR:-.}/trustlines/shared:/shared/
     depends_on:
       - trustlines-node
-    command: -r /reports -d /state -c /config/chain-spec/trustlines-spec.json -u http://laika-testnet.node:8545 -m
+    command: -r /reports -d /state -c /shared/trustlines-spec.json -u http://laika-testnet.node:8545 -m
 
   watchtower:
     image: v2tec/watchtower

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -85,6 +85,23 @@ services:
       - mainnet-node
     command: -c /config/config.toml
 
+  tlbc-monitor:
+    image: trustlines/tlbc-monitor:latest  # TODO: switch to master?
+    container_name: tlbc-monitor
+    restart: unless-stopped
+    mem_limit: 512M
+    mem_reservation: 16M
+    stop_grace_period: 30s
+    networks:
+      - laika-testnet
+    volumes:
+      - ${HOST_BASE_DIR:-.}/trustlines/monitor/reports:/reports
+      - ${HOST_BASE_DIR:-.}/trustlines/monitor/state:/state
+      - ${HOST_BASE_DIR:-.}/trustlines/shared-config:/config/chain-spec
+    depends_on:
+      - trustlines-node
+    command: -r /reports -d /state -c /config/chain-spec/trustlines-spec.json -u http://laika-testnet.node:8545 -m
+
   watchtower:
     image: v2tec/watchtower
     container_name: watchtower

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -20,7 +20,7 @@ services:
       - ${HOST_BASE_DIR:-.}/trustlines/databases:/data
       - ${HOST_BASE_DIR:-.}/trustlines/config:/config/custom
       - ${HOST_BASE_DIR:-.}/trustlines/enode:/config/network
-      - ${HOST_BASE_DIR:-.}/shared-config:/config/chain-spec
+      - ${HOST_BASE_DIR:-.}/trustlines/shared-config:/config/chain-spec
     command: >-
       --role ${ROLE}
       --address ${VALIDATOR_ADDRESS}

--- a/docker/parity_wrapper.sh
+++ b/docker/parity_wrapper.sh
@@ -204,11 +204,11 @@ function runParity() {
 
 function copySpecFileToSharedVolume() {
   echo "Copying trustline spec file to shared volume"
-  cp /config/trustlines-spec.json /shared-config/trustlines-spec.json
+  cp /config/trustlines-spec.json /config/chain-spec/trustlines-spec.json
 }
 
 # Getting Started
 parseArguments
 adjustConfiguration
-copySpecFileToVolume
+copySpecFileToSharedVolume
 runParity

--- a/docker/parity_wrapper.sh
+++ b/docker/parity_wrapper.sh
@@ -204,7 +204,7 @@ function runParity() {
 
 function copySpecFileToSharedVolume() {
   echo "Copying trustline spec file to shared volume"
-  cp /config/trustlines-spec.json /config/chain-spec/trustlines-spec.json
+  cp /config/trustlines-spec.json /shared/trustlines-spec.json
 }
 
 # Getting Started

--- a/tools/quickstart/quickstart/bridge.py
+++ b/tools/quickstart/quickstart/bridge.py
@@ -23,15 +23,16 @@ from quickstart.utils import is_bridge_prepared, is_validator_account_prepared
 
 def setup_interactively() -> None:
     if is_bridge_prepared():
-        click.echo("The bridge client has already been set up.\n")
+        click.echo("\nThe bridge client has already been set up.")
         return
     if not is_validator_account_prepared():
-        click.echo("No bridge node will be set up as running as a non-validator.\n")
+        click.echo("\nNo bridge node will be set up as running as a non-validator.")
         return
 
     click.echo(
         "\n".join(
             (
+                "",
                 fill(
                     "As a validator of the Trustlines blockchain, you are required to run a "
                     "bridge node. Checkout the following link for more information:"

--- a/tools/quickstart/quickstart/cli.py
+++ b/tools/quickstart/quickstart/cli.py
@@ -16,7 +16,6 @@ from quickstart import bridge, docker, monitor, netstats, validator_account
     default=os.getcwd(),
 )
 def main(host_base_dir):
-    click.echo()
     click.echo(
         "\n".join(
             (

--- a/tools/quickstart/quickstart/cli.py
+++ b/tools/quickstart/quickstart/cli.py
@@ -3,7 +3,7 @@ from textwrap import fill
 
 import click
 
-from quickstart import bridge, docker, netstats, validator_account
+from quickstart import bridge, docker, monitor, netstats, validator_account
 
 
 @click.command()
@@ -31,12 +31,12 @@ def main(host_base_dir):
                     "restarted and no configuration will be overwritten. It is possible to enable "
                     "additional components that you have chosen not to configure in earlier runs."
                 ),
-                "",
             )
         )
     )
 
     validator_account.setup_interactively()
+    monitor.setup_interactively()
     bridge.setup_interactively()
     netstats.setup_interactively()
     docker.update_and_start(host_base_dir)

--- a/tools/quickstart/quickstart/constants.py
+++ b/tools/quickstart/quickstart/constants.py
@@ -40,3 +40,9 @@ BRIDGE_CONFIG_KEYSTORE_PASSWORD_PATH = os.path.join(
 BRIDGE_DOCUMENTATION_URL = (
     "https://github.com/trustlines-protocol/blockchain/tree/master/tools/bridge"
 )
+
+MONITOR_DIR = os.path.join(BASE_DIR, "monitor")
+MONITOR_REPORTS_DIR = os.path.join(MONITOR_DIR, "reports")
+MONITOR_STATE_PATH = os.path.join(MONITOR_DIR, "reports")
+
+SHARED_CHAIN_SPEC_PATH = os.path.join(BASE_DIR, "shared-config/trustlines-spec.json")

--- a/tools/quickstart/quickstart/constants.py
+++ b/tools/quickstart/quickstart/constants.py
@@ -45,4 +45,4 @@ MONITOR_DIR = os.path.join(BASE_DIR, "monitor")
 MONITOR_REPORTS_DIR = os.path.join(MONITOR_DIR, "reports")
 MONITOR_STATE_PATH = os.path.join(MONITOR_DIR, "reports")
 
-SHARED_CHAIN_SPEC_PATH = os.path.join(BASE_DIR, "shared-config/trustlines-spec.json")
+SHARED_CHAIN_SPEC_PATH = os.path.join(BASE_DIR, "shared/trustlines-spec.json")

--- a/tools/quickstart/quickstart/docker.py
+++ b/tools/quickstart/quickstart/docker.py
@@ -24,7 +24,8 @@ def update_and_start(host_base_dir: str) -> None:
         "docker-compose.yml"
     ):
         raise click.ClickException(
-            fill(
+            "\n"
+            + fill(
                 "Expecting a docker-compose configuration file at the current directory "
                 "with a standard name. ('docker-compose.yaml' or 'docker-compose.yml')"
             )

--- a/tools/quickstart/quickstart/netstats.py
+++ b/tools/quickstart/quickstart/netstats.py
@@ -17,7 +17,7 @@ INSTANCE_NAME={instance_name}
 
 def setup_interactively() -> None:
     if is_netstats_prepared():
-        click.echo("\nThe netstats client has already been set up.\n")
+        click.echo("\nThe netstats client has already been set up.")
         return
 
     click.echo(

--- a/tools/quickstart/quickstart/utils.py
+++ b/tools/quickstart/quickstart/utils.py
@@ -13,6 +13,7 @@ from quickstart.constants import (
     ADDRESS_FILE_PATH,
     BRIDGE_CONFIG_FILE_EXTERNAL,
     KEYSTORE_FILE_PATH,
+    MONITOR_DIR,
     NETSTATS_ENV_FILE_PATH,
     PASSWORD_FILE_PATH,
 )
@@ -66,6 +67,10 @@ def is_netstats_prepared() -> bool:
 
 def is_bridge_prepared() -> bool:
     return non_empty_file_exists(BRIDGE_CONFIG_FILE_EXTERNAL)
+
+
+def is_monitor_prepared() -> bool:
+    return os.path.isdir(MONITOR_DIR)
 
 
 class TrustlinesFiles:

--- a/tools/quickstart/quickstart/validator_account.py
+++ b/tools/quickstart/quickstart/validator_account.py
@@ -26,10 +26,9 @@ from quickstart.utils import (
 
 def setup_interactively() -> None:
     if is_validator_account_prepared():
-        click.echo("A validator account has already been set up.\n")
+        click.echo("\nA validator account has already been set up.")
         return
     if not prompt_setup_as_validator():
-        click.echo("\n")
         return
 
     ensure_clean_setup()
@@ -57,12 +56,12 @@ def setup_interactively() -> None:
     else:
         assert False, "unreachable"
 
-    click.echo("Validator account setup complete.\n")
+    click.echo("Validator account setup complete.")
 
 
 def prompt_setup_as_validator():
     choice = click.prompt(
-        "Do you want to set up a validator account (1) or run a regular node (2)?",
+        "\nDo you want to set up a validator account (1) or run a regular node (2)?",
         type=click.Choice(("1", "2")),
         show_choices=False,
     )


### PR DESCRIPTION
Closes https://github.com/trustlines-network/project/issues/652

The monitor actually doesn't run at the moment because it requires https://github.com/trustlines-protocol/tlbc-monitor/pull/76. So I could only test it up to the point at which it attempts to start the monitor container.