### PR TITLE
Update parity-wrapper to copy chain spec file to shared volume

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -18,6 +18,7 @@ services:
       - ${HOST_BASE_DIR:-.}/trustlines/databases:/data
       - ${HOST_BASE_DIR:-.}/trustlines/config:/config/custom
       - ${HOST_BASE_DIR:-.}/trustlines/enode:/config/network
+      - ${HOST_BASE_DIR:-.}/shared-config:/config/chain-spec
     command: >-
       --role ${ROLE}
       --address ${VALIDATOR_ADDRESS}

--- a/docker/parity_wrapper.sh
+++ b/docker/parity_wrapper.sh
@@ -202,7 +202,13 @@ function runParity() {
   exec $PARITY_BIN $PARITY_ARGS
 }
 
+function copySpecFileToSharedVolume() {
+  echo "Copying trustline spec file to shared volume"
+  cp /config/trustlines-spec.json /shared-config/trustlines-spec.json
+}
+
 # Getting Started
 parseArguments
 adjustConfiguration
+copySpecFileToVolume
 runParity


### PR DESCRIPTION
Update parity-wrapper to copy chain spec file to shared volume to get spec file out of container
closes: https://github.com/trustlines-protocol/blockchain/issues/415