### PR TITLE
"Pin" mainnet node versions to stable

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -26,7 +26,7 @@ services:
       --address ${VALIDATOR_ADDRESS}
 
   mainnet-node:
-    image: parity/parity:v2.5.5-stable
+    image: parity/parity:stable
     # Use dotted name to pass the bridge client URL validation.
     container_name: mainnet.node
     restart: unless-stopped

--- a/tools/bridge/docker/docker-compose-base.yaml
+++ b/tools/bridge/docker/docker-compose-base.yaml
@@ -1,7 +1,7 @@
 version: "2.4"
 services:
   node_foreign:
-    image: parity/parity:v2.5.5-stable
+    image: parity/parity:stable
     command:
       - "--light"
       - "--no-download"


### PR DESCRIPTION
Closes #430 

I've tested the new version by running the bridge end to end test with it. I'm uncertain if we should do this in CI: On the one hand, we regularly test with the newest stable release, on the other hand it makes the tests less deterministic.