### PR TITLE
Optimize gas for bridge transfers

### DIFF
--- a/contracts/contracts/bridge/HomeBridge.sol
+++ b/contracts/contracts/bridge/HomeBridge.sol
@@ -6,7 +6,6 @@ contract HomeBridge {
     struct TransferState {
         mapping(address => bool) isConfirmedByValidator;
         address payable[] confirmingValidators;
-        uint16 numConfirmations;
         bool isCompleted;
     }
 
@@ -151,7 +150,6 @@ contract HomeBridge {
                     1];
                 delete confirmingValidators[confirmingValidators.length - 1];
                 confirmingValidators.length--;
-                transferState[transferStateId].numConfirmations--;
             }
         }
     }
@@ -176,7 +174,6 @@ contract HomeBridge {
 
         transferState[transferStateId].isConfirmedByValidator[validator] = true;
         transferState[transferStateId].confirmingValidators.push(validator);
-        transferState[transferStateId].numConfirmations += 1;
 
         return true;
     }
@@ -203,13 +200,19 @@ contract HomeBridge {
            purgeConfirmationsFromExValidators if there were no changes.
         */
 
-        if (transferState[transferStateId].numConfirmations < numRequired) {
+        if (
+            transferState[transferStateId].confirmingValidators.length <
+            numRequired
+        ) {
             return false;
         }
 
         purgeConfirmationsFromExValidators(transferStateId);
 
-        if (transferState[transferStateId].numConfirmations < numRequired) {
+        if (
+            transferState[transferStateId].confirmingValidators.length <
+            numRequired
+        ) {
             return false;
         }
 

--- a/contracts/contracts/tlc-validator/ValidatorProxy.sol
+++ b/contracts/contracts/tlc-validator/ValidatorProxy.sol
@@ -1,7 +1,5 @@
 pragma solidity ^0.5.8;
 
-import "./ValidatorSet.sol";
-
 /**
     This contract gives access to an up to date validator set on chain, that can be used by any other contracts.
     Its validator set is to be updated by validators contracts when the system address calls finalizeChange().

--- a/contracts/contracts/tlc-validator/ValidatorSet.sol
+++ b/contracts/contracts/tlc-validator/ValidatorSet.sol
@@ -164,5 +164,4 @@ contract ValidatorSet {
         finalized = false;
         emit InitiateChange(blockhash(block.number - 1), _newValidatorSet);
     }
-
 }


### PR DESCRIPTION
Optimize gas for bridge transfers by removing useless struct member numConfirmations and using length of confirming validators instead

Remove useless import in ValidatorProxy.

Test for regular transfer without validator set changes with 50 validators, 50% of which are required to complete the transfer

### with optimization:

first confirm: 97_156
other confirm: 82_156
last confirm: 217_578
useless confirm: 28_234

total confirm: 2_204_322


### without optimization:

first confirm: 117_442
other confirm: 87_442
last confirm: 203_070
useless confirm: 28_245

total confirm: 2_331_678