### PR TITLE
Feature/delete confirming validators after complete

### DIFF
--- a/contracts/contracts/bridge/HomeBridge.sol
+++ b/contracts/contracts/bridge/HomeBridge.sol
@@ -75,7 +75,7 @@ contract HomeBridge {
         if (_confirmTransfer(transferStateId, msg.sender)) {
             // We have to emit the events here, because _confirmTransfer
             // doesn't even receive the necessary information to do it on
-            // it's own
+            // its own
 
             emit Confirmation(
                 transferHash,
@@ -88,6 +88,7 @@ contract HomeBridge {
 
         if (requiredConfirmationsReached(transferStateId)) {
             transferState[transferStateId].isCompleted = true;
+            delete transferState[transferStateId].confirmingValidators;
             bool coinTransferSuccessful = recipient.send(amount);
             emit TransferCompleted(
                 transferHash,
@@ -190,7 +191,7 @@ contract HomeBridge {
            confirmations from ex-validators.
 
            This means that old confirmations stay valid over validator set changes given
-           that the validator doesn't loose it's validator status.
+           that the validator doesn't lose its validator status.
 
            The double check is here to save some gas. If checking the validator
            status for all confirming validators becomes too costly, we can introduce

--- a/contracts/contracts/bridge/HomeBridge.sol
+++ b/contracts/contracts/bridge/HomeBridge.sol
@@ -6,7 +6,6 @@ contract HomeBridge {
     struct TransferState {
         mapping(address => bool) isConfirmedByValidator;
         address payable[] confirmingValidators;
-        uint16 numConfirmations;
         bool isCompleted;
     }
 
@@ -151,7 +150,6 @@ contract HomeBridge {
                     1];
                 delete confirmingValidators[confirmingValidators.length - 1];
                 confirmingValidators.length--;
-                transferState[transferStateId].numConfirmations--;
             }
         }
     }
@@ -176,7 +174,6 @@ contract HomeBridge {
 
         transferState[transferStateId].isConfirmedByValidator[validator] = true;
         transferState[transferStateId].confirmingValidators.push(validator);
-        transferState[transferStateId].numConfirmations += 1;
 
         return true;
     }
@@ -203,13 +200,19 @@ contract HomeBridge {
            purgeConfirmationsFromExValidators if there were no changes.
         */
 
-        if (transferState[transferStateId].numConfirmations < numRequired) {
+        if (
+            transferState[transferStateId].confirmingValidators.length <
+            numRequired
+        ) {
             return false;
         }
 
         purgeConfirmationsFromExValidators(transferStateId);
 
-        if (transferState[transferStateId].numConfirmations < numRequired) {
+        if (
+            transferState[transferStateId].confirmingValidators.length <
+            numRequired
+        ) {
             return false;
         }
 

--- a/contracts/contracts/tlc-validator/ValidatorProxy.sol
+++ b/contracts/contracts/tlc-validator/ValidatorProxy.sol
@@ -1,7 +1,5 @@
 pragma solidity ^0.5.8;
 
-import "./ValidatorSet.sol";
-
 /**
     This contract gives access to an up to date validator set on chain, that can be used by any other contracts.
     Its validator set is to be updated by validators contracts when the system address calls finalizeChange().

--- a/contracts/contracts/tlc-validator/ValidatorSet.sol
+++ b/contracts/contracts/tlc-validator/ValidatorSet.sol
@@ -164,5 +164,4 @@ contract ValidatorSet {
         finalized = false;
         emit InitiateChange(blockhash(block.number - 1), _newValidatorSet);
     }
-
 }


### PR DESCRIPTION
Gas costs for a transfer with 50 validators, require 50% to complete transfer, and no validator set changes:

### with optimization:

first confirm: 97_156
other confirm: 82_156
last confirm: 169_808
useless confirm: 28_234

total confirm: 2_156_552

### without optimization:

first confirm: 97_156
other confirm: 82_156
last confirm: 217_578
useless confirm: 28_234

total confirm: 2_204_322