### PR TITLE
Update bridge so that it waits for the foreign chain to be fully synced

### DIFF
--- a/tools/bridge/bridge/main.py
+++ b/tools/bridge/bridge/main.py
@@ -67,7 +67,7 @@ def configure_logging(config):
     )
 
 
-def wait_for_chain_synced_until(w3, start_block_number, timeout, chain_role):
+def wait_for_chain_synced_until_block(w3, start_block_number, timeout, chain_role):
     retry = tenacity.retry(
         wait=tenacity.wait_exponential(multiplier=1, min=5, max=timeout),
         before_sleep=tenacity.before_sleep_log(logger, logging.WARN),
@@ -132,6 +132,60 @@ def wait_for_chain_synced_until(w3, start_block_number, timeout, chain_role):
             gevent.sleep(HOME_CHAIN_STEP_DURATION)
 
 
+def wait_for_chain_fully_synced_past_block(w3, start_block_number, timeout, chain_role):
+    retry = tenacity.retry(
+        wait=tenacity.wait_exponential(multiplier=1, min=5, max=timeout),
+        before_sleep=tenacity.before_sleep_log(logger, logging.WARN),
+    )
+
+    @retry
+    def _rpc_syncing():
+        return w3.eth.syncing
+
+    @retry
+    def _rpc_block_number():
+        return w3.eth.blockNumber
+
+    while True:
+        syncing = _rpc_syncing()
+        if syncing is False:
+            highest_block_number = _rpc_block_number()
+            current_block_number = highest_block_number
+        else:
+            current_block_number = syncing["currentBlock"]
+            highest_block_number = syncing["highestBlock"]
+
+        start_block_passed = current_block_number >= start_block_number
+
+        if syncing:
+            logger.info(
+                "%s node is synced until block number %d of %d, but is not fully synced "
+                "and not past start block number %d yet. Waiting...",
+                chain_role.value,
+                current_block_number,
+                highest_block_number,
+                start_block_number,
+            )
+        else:
+            if start_block_passed:
+                logger.info(
+                    "%s node is fully synced to head number %d and has passed the event fetch start block number %d",
+                    chain_role.value,
+                    highest_block_number,
+                    start_block_number,
+                )
+                break
+            else:
+                logger.info(
+                    "%s node is fully synced until head number %d, but chain hasn't reached event "
+                    "fetch start block number %d yet. Waiting...",
+                    chain_role.value,
+                    highest_block_number,
+                    start_block_number,
+                )
+        gevent.sleep(HOME_CHAIN_STEP_DURATION)
+
+
 def wait_for_start_blocks(config):
     w3_home = make_w3_home(config)
     w3_foreign = make_w3_foreign(config)
@@ -146,10 +200,10 @@ def wait_for_start_blocks(config):
     home_chain_rpc_timeout = config["home_chain"]["rpc_timeout"]
     foreign_chain_rpc_timeout = config["home_chain"]["rpc_timeout"]
 
-    wait_for_chain_synced_until(
+    wait_for_chain_synced_until_block(
         w3_home, home_chain_start_block_number, home_chain_rpc_timeout, ChainRole.home
     )
-    wait_for_chain_synced_until(
+    wait_for_chain_fully_synced_past_block(
         w3_foreign,
         foreign_chain_start_block_number,
         foreign_chain_rpc_timeout,


### PR DESCRIPTION
Update bridge so that it waits for the foreign chain to be fully synced before starting transfers.

It seems that when a light node is not fully synced, requests are not properly handled.

I could not find a good way to reduce redundancy in between `wait_for_chain_synced_until_block` and `wait_for_chain_fully_synced_past_block` without having one function that does two different things with a flag, since most of it is logging infos.

closes: https://github.com/trustlines-protocol/blockchain/issues/452