### PR TITLE
Mount the proper path into volume for foreign node

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -41,12 +41,14 @@ services:
           # Use dotted name to pass the bridge client URL validation.
           - mainnet.node
     volumes:
-      - ${HOST_BASE_DIR:-.}/trustlines/databases:/home/parity/.local/share/io.parity.ethereum/chains_light
+      # Need to adjust the path if using different chain
+      - ${HOST_BASE_DIR:-.}/trustlines/databases/mainnet:/data/database
     command: >-
       --light
       --no-download
       --auto-update none
       --chain goerli
+      --db-path /data/database
       --base-path /data
       --no-hardware-wallets
       --jsonrpc-interface all


### PR DESCRIPTION
Mount the proper path into volume for foreign chain node to save database

This allows for the node to not reset syncing when restarted.

I avoid hard-coding `/path/goerli` in the mounted volume path, in case we change chain to the actual mainnet. This result in a more obfuscated hierarchy for the host: `trustlines/databases/goerli/goerli/db` but will avoid potential mistakes when switching `--chain goerli` to `--chain mainnet`.

closes https://github.com/trustlines-protocol/blockchain/issues/457