### PR TITLE
Update contract-deploy-tools version to 0.6.1

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -11,7 +11,7 @@ certifi==2019.6.16
 cfgv==2.0.1
 chardet==3.0.4
 Click==7.0
-contract-deploy-tools==0.5.1
+contract-deploy-tools==0.6.1
 cytoolz==0.10.0
 entrypoints==0.3
 eth-abi==2.0.0


### PR DESCRIPTION
Related to: trustlines-network/project#703