### PR TITLE
Disable warp mode

### DIFF
--- a/docker/parity_wrapper.sh
+++ b/docker/parity_wrapper.sh
@@ -60,7 +60,7 @@ IFS=' ' read -r -a ARG_VEC <<<"$@"
 # Adjustable configuration values.
 ROLE="observer"
 ADDRESS=""
-PARITY_ARGS="--no-color --jsonrpc-interface all"
+PARITY_ARGS="--no-warp --no-color --jsonrpc-interface all"
 
 # Internal stuff.
 declare -a VALID_ROLE_LIST=(


### PR DESCRIPTION
With active warp mode the parity node will signal that it is finished
with syncing, but when we ask for events it will return an empty list,
because in fact it didn't fully sync.

This resulted in the bridge confirming transfers twice.

This commit changes the docker image to not use warp mode, because I
consider this behaviour a general problem.

See https://github.com/trustlines-protocol/blockchain/issues/473