### PR TITLE
Copy docker-compose file to host during quickstart

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,7 @@ FROM ubuntu:18.04@sha256:f08638ec7ddc90065187e7eabdfac3c96e5ff0f6b2f1762cf31a4f4
 ## Environment
 ENV HOME=/home/parity
 ENV PARITY_HOME_DIR=$HOME/.local/share/io.parity.ethereum
-ENV PARITY_CONFIG_FILE_CHAIN=$PARITY_HOME_DIR/laika-spec.json
+ENV PARITY_CONFIG_FILE_CHAIN=$PARITY_HOME_DIR/trustlines-spec.json
 ENV PARITY_CONFIG_FILE_TEMPLATE=$PARITY_HOME_DIR/config-template.toml
 ENV PARITY_DATA_DIR=$PARITY_HOME_DIR/chains
 ENV PARITY_BIN=/usr/local/bin/parity

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -100,7 +100,7 @@ services:
       - ${HOST_BASE_DIR:-.}/shared:/shared/
     depends_on:
       - trustlines-node
-    command: -r /reports -d /state -c /shared/laika-spec.json -u http://laika-testnet.node:8545 -m
+    command: -r /reports -d /state -c /shared/trustlines-spec.json -u http://laika-testnet.node:8545 -m
 
   watchtower:
     image: containrrr/watchtower

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -18,10 +18,10 @@ services:
       - 30300:30300
       - 30300:30300/udp
     volumes:
-      - ${HOST_BASE_DIR:-.}/trustlines/databases:/data
-      - ${HOST_BASE_DIR:-.}/trustlines/config:/config/custom
-      - ${HOST_BASE_DIR:-.}/trustlines/enode:/config/network
-      - ${HOST_BASE_DIR:-.}/trustlines/shared:/shared/
+      - ${HOST_BASE_DIR:-.}/databases:/data
+      - ${HOST_BASE_DIR:-.}/config:/config/custom
+      - ${HOST_BASE_DIR:-.}/enode:/config/network
+      - ${HOST_BASE_DIR:-.}/shared:/shared/
     command: >-
       --role ${ROLE}
       --address ${VALIDATOR_ADDRESS}
@@ -42,7 +42,7 @@ services:
           - mainnet.node
     volumes:
       # Need to adjust the path if using different chain
-      - ${HOST_BASE_DIR:-.}/trustlines/databases/mainnet:/data/database
+      - ${HOST_BASE_DIR:-.}/databases/mainnet:/data/database
     command: >-
       --light
       --no-download
@@ -62,7 +62,7 @@ services:
   netstats-client:
     image: trustlines/netstats-client:master
     restart: always
-    env_file: ./trustlines/netstats-env
+    env_file: ./netstats-env
     environment:
       - RPC_HOST=laika-testnet.node
     networks:
@@ -80,8 +80,7 @@ services:
       - laika-testnet
       - mainnet
     volumes:
-      - ${HOST_BASE_DIR:-.}/trustlines/config:/config
-      - ${HOST_BASE_DIR:-.}/trustlines/bridge-config.toml:/config/config.toml
+      - ${HOST_BASE_DIR:-.}/bridge-config.toml:/config/config.toml
     depends_on:
       - trustlines-node
       - mainnet-node
@@ -96,9 +95,9 @@ services:
     networks:
       - laika-testnet
     volumes:
-      - ${HOST_BASE_DIR:-.}/trustlines/monitor/reports:/reports
-      - ${HOST_BASE_DIR:-.}/trustlines/monitor/state:/state
-      - ${HOST_BASE_DIR:-.}/trustlines/shared:/shared/
+      - ${HOST_BASE_DIR:-.}/monitor/reports:/reports
+      - ${HOST_BASE_DIR:-.}/monitor/state:/state
+      - ${HOST_BASE_DIR:-.}/shared:/shared/
     depends_on:
       - trustlines-node
     command: -r /reports -d /state -c /shared/laika-spec.json -u http://laika-testnet.node:8545 -m

--- a/docker/parity_wrapper.sh
+++ b/docker/parity_wrapper.sh
@@ -204,8 +204,8 @@ function runParity() {
 
 function copySpecFileToSharedVolume() {
   if [[ -d "$SHARED_VOLUME_PATH" ]]; then
-    echo "Copying laika spec file to shared volume"
-    cp /config/laika-spec.json "$SHARED_VOLUME_PATH/laika-spec.json"
+    echo "Copying chain spec file to shared volume"
+    cp /config/trustlines-spec.json "$SHARED_VOLUME_PATH/trustlines-spec.json"
   else
     echo "Shared volume apparently not mounted, skip copying chain spec file"
   fi

--- a/tools/quickstart/quickstart/bridge.py
+++ b/tools/quickstart/quickstart/bridge.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 from textwrap import fill
 from typing import Dict
@@ -21,11 +22,11 @@ from quickstart.constants import (
 from quickstart.utils import is_bridge_prepared, is_validator_account_prepared
 
 
-def setup_interactively() -> None:
-    if is_bridge_prepared():
+def setup_interactively(base_dir) -> None:
+    if is_bridge_prepared(base_dir):
         click.echo("\nThe bridge client has already been set up.")
         return
-    if not is_validator_account_prepared():
+    if not is_validator_account_prepared(base_dir):
         click.echo("\nNo bridge node will be set up as running as a non-validator.")
         return
 
@@ -46,7 +47,7 @@ def setup_interactively() -> None:
         "Do you want to set up a bridge node now? (recommended)", default=True
     ):
         # Necessary to make docker-compose not complain about it.
-        Path(BRIDGE_CONFIG_FILE_EXTERNAL).touch()
+        Path(os.path.join(base_dir, BRIDGE_CONFIG_FILE_EXTERNAL)).touch()
         return
 
     configuration = get_bridge_configuration(
@@ -61,7 +62,7 @@ def setup_interactively() -> None:
         BRIDGE_CONFIG_KEYSTORE_PASSWORD_PATH,
     )
 
-    with open(BRIDGE_CONFIG_FILE_EXTERNAL, "w") as config_file:
+    with open(os.path.join(base_dir, BRIDGE_CONFIG_FILE_EXTERNAL), "w") as config_file:
         toml.dump(configuration, config_file)
 
     click.echo("Bridge client setup complete.")

--- a/tools/quickstart/quickstart/cli.py
+++ b/tools/quickstart/quickstart/cli.py
@@ -1,4 +1,3 @@
-import os
 from textwrap import fill
 
 import click
@@ -13,9 +12,24 @@ from quickstart import bridge, docker, monitor, netstats, validator_account
         "absolute path to use for docker volumes (only relevant when run from inside a docker "
         "container itself)"
     ),
-    default=os.getcwd(),
+    type=click.Path(),  # Can not check for exist, because path is on host
+    default=None,
 )
-def main(host_base_dir):
+@click.option(
+    "--docker-compose-file",
+    help="path to the docker compose file to use",
+    type=click.Path(exists=True, dir_okay=False),
+    default="docker-compose.yaml",
+)
+@click.option(
+    "-d",
+    "--base-dir",
+    help="path where everything is installed into",
+    type=click.Path(file_okay=False),
+    default="trustlines",
+)
+@click.option("--project-name", help="project name", default="trustlines")
+def main(host_base_dir, docker_compose_file, base_dir, project_name):
     click.echo(
         "\n".join(
             (
@@ -34,11 +48,16 @@ def main(host_base_dir):
         )
     )
 
-    validator_account.setup_interactively()
-    monitor.setup_interactively()
-    bridge.setup_interactively()
-    netstats.setup_interactively()
-    docker.update_and_start(host_base_dir)
+    validator_account.setup_interactively(base_dir=base_dir)
+    monitor.setup_interactively(base_dir=base_dir)
+    bridge.setup_interactively(base_dir=base_dir)
+    netstats.setup_interactively(base_dir=base_dir)
+    docker.setup_interactivaly(
+        base_dir=base_dir, docker_compose_file=docker_compose_file
+    )
+    docker.update_and_start(
+        base_dir=base_dir, host_base_dir=host_base_dir, project_name=project_name
+    )
 
 
 if __name__ == "__main__":

--- a/tools/quickstart/quickstart/constants.py
+++ b/tools/quickstart/quickstart/constants.py
@@ -1,9 +1,8 @@
 import os
 
-BASE_DIR = "trustlines"  # Relative to the current working directory
-CONFIG_DIR = os.path.join(BASE_DIR, "config")
-ENODE_DIR = os.path.join(BASE_DIR, "enode")
-DATABASE_DIR = os.path.join(BASE_DIR, "databases")
+CONFIG_DIR = "config"
+ENODE_DIR = "enode"
+DATABASE_DIR = "databases"
 KEY_DIR = os.path.join(CONFIG_DIR, "keys", "Trustlines")
 
 KEYSTORE_FILE_NAME = "account.json"
@@ -13,10 +12,10 @@ KEYSTORE_FILE_PATH = os.path.join(KEY_DIR, KEYSTORE_FILE_NAME)
 PASSWORD_FILE_PATH = os.path.join(CONFIG_DIR, PASSWORD_FILE_NAME)
 ADDRESS_FILE_PATH = os.path.join(CONFIG_DIR, "address")
 
-NETSTATS_ENV_FILE_PATH = os.path.join(BASE_DIR, "netstats-env")
+NETSTATS_ENV_FILE_PATH = "netstats-env"
 NETSTATS_SERVER_BASE_URL = "https://laikanetstats.trustlines.foundation/"
 
-BRIDGE_CONFIG_FILE_EXTERNAL = os.path.join(BASE_DIR, "bridge-config.toml")
+BRIDGE_CONFIG_FILE_EXTERNAL = "bridge-config.toml"
 BRIDGE_CONFIG_DIR_INTERNAL = "/config"
 BRIDGE_CONFIG_FOREIGN_RPC_URL = "http://mainnet.node:8545"
 BRIDGE_CONFIG_HOME_RPC_URL = "http://laika-testnet.node:8545"
@@ -41,8 +40,7 @@ BRIDGE_DOCUMENTATION_URL = (
     "https://github.com/trustlines-protocol/blockchain/tree/master/tools/bridge"
 )
 
-MONITOR_DIR = os.path.join(BASE_DIR, "monitor")
+MONITOR_DIR = "monitor"
 MONITOR_REPORTS_DIR = os.path.join(MONITOR_DIR, "reports")
-MONITOR_STATE_PATH = os.path.join(MONITOR_DIR, "reports")
 
-SHARED_CHAIN_SPEC_PATH = os.path.join(BASE_DIR, "shared/laika-spec.json")
+SHARED_CHAIN_SPEC_PATH = "shared/laika-spec.json"

--- a/tools/quickstart/quickstart/constants.py
+++ b/tools/quickstart/quickstart/constants.py
@@ -43,4 +43,4 @@ BRIDGE_DOCUMENTATION_URL = (
 MONITOR_DIR = "monitor"
 MONITOR_REPORTS_DIR = os.path.join(MONITOR_DIR, "reports")
 
-SHARED_CHAIN_SPEC_PATH = "shared/laika-spec.json"
+SHARED_CHAIN_SPEC_PATH = "shared/trustlines-spec.json"

--- a/tools/quickstart/quickstart/docker.py
+++ b/tools/quickstart/quickstart/docker.py
@@ -1,4 +1,6 @@
+import difflib
 import os
+import shutil
 import subprocess
 import time
 from textwrap import fill
@@ -19,10 +21,40 @@ from quickstart.validator_account import get_validator_address
 LEGACY_CONTAINER_NAMES = ["watchtower-testnet", "trustlines-testnet"]
 
 
-def update_and_start(host_base_dir: str) -> None:
-    if not os.path.isfile("docker-compose.yaml") and not os.path.isfile(
-        "docker-compose.yml"
-    ):
+def setup_interactivaly(base_dir, docker_compose_file):
+    if does_docker_compose_file_exist(base_dir):
+        while True:
+            choice = click.prompt(
+                fill(
+                    "You already seem to have a docker compose file. "
+                    "If you did not change it, you can safely override it.\n"
+                    "Override with default (1), keep own (2), or show diff (3) ?"
+                )
+                + "\n",
+                type=click.Choice(("1", "2", "3")),
+                show_choices=False,
+            )
+
+            if choice == "1":
+                copy_default_docker_file(
+                    base_dir=base_dir, docker_compose_file=docker_compose_file
+                )
+                break
+            elif choice == "2":
+                # Nothing to do
+                break
+            elif choice == "3":
+                show_diff(base_dir=base_dir, docker_compose_file=docker_compose_file)
+            else:
+                assert False, "unreachable"
+    else:
+        copy_default_docker_file(
+            base_dir=base_dir, docker_compose_file=docker_compose_file
+        )
+
+
+def update_and_start(*, base_dir, host_base_dir, project_name) -> None:
+    if not does_docker_compose_file_exist(base_dir):
         raise click.ClickException(
             "\n"
             + fill(
@@ -32,29 +64,43 @@ def update_and_start(host_base_dir: str) -> None:
         )
 
     main_docker_service_names = ["trustlines-node", "watchtower"]
-    optional_docker_service_names = get_optional_docker_service_names()
+    optional_docker_service_names = get_optional_docker_service_names(base_dir)
     all_docker_service_names = (
         main_docker_service_names + optional_docker_service_names + ["tlbc-monitor"]
     )
 
-    base_docker_environment_variables = {**os.environ, "HOST_BASE_DIR": host_base_dir}
-    if is_validator_account_prepared():
-        docker_environment_variables = {
-            **base_docker_environment_variables,
-            "VALIDATOR_ADDRESS": get_validator_address(),
+    default_env_vars = {"COMPOSE_PROJECT_NAME": project_name}
+    if is_validator_account_prepared(base_dir):
+        env_variables = {
+            **default_env_vars,
+            "VALIDATOR_ADDRESS": get_validator_address(base_dir),
             "ROLE": "validator",
         }
         click.echo("\nNode will run as a validator")
     else:
-        docker_environment_variables = {
-            **base_docker_environment_variables,
+        env_variables = {
+            **default_env_vars,
             "VALIDATOR_ADDRESS": "",
             "ROLE": "observer",
         }
         click.echo("\nNode will run as a non-validator")
 
+    with open(os.path.join(base_dir, ".env"), mode="w") as env_file:
+        env_file.writelines(
+            f"{key}={value}\n" for (key, value) in env_variables.items()
+        )
+
+    runtime_env_variables = {
+        **os.environ,
+        **env_variables,
+        "COMPOSE_FILE": os.path.join(base_dir, "docker-compose.yaml"),
+    }
+
+    if host_base_dir is not None:
+        runtime_env_variables["HOST_BASE_DIR"] = host_base_dir
+
     run_kwargs = {
-        "env": docker_environment_variables,
+        "env": runtime_env_variables,
         "stdout": subprocess.PIPE,
         "stderr": subprocess.PIPE,
         "universal_newlines": True,
@@ -87,7 +133,7 @@ def update_and_start(host_base_dir: str) -> None:
             **run_kwargs,
         )
 
-        wait_for_chain_spec()
+        wait_for_chain_spec(base_dir)
 
         subprocess.run(
             ["docker-compose", "start", "tlbc-monitor"], check=True, **run_kwargs
@@ -110,19 +156,68 @@ def update_and_start(host_base_dir: str) -> None:
     click.echo("\nAll services are running. Congratulations!")
 
 
-def wait_for_chain_spec() -> None:
-    while not os.path.exists(SHARED_CHAIN_SPEC_PATH):
+def wait_for_chain_spec(base_dir) -> None:
+    while not os.path.exists(os.path.join(base_dir, SHARED_CHAIN_SPEC_PATH)):
         time.sleep(1)
 
 
-def get_optional_docker_service_names() -> List[str]:
+def get_optional_docker_service_names(base_dir) -> List[str]:
     docker_service_names = []
 
-    if is_netstats_prepared():
+    if is_netstats_prepared(base_dir=base_dir):
         docker_service_names.append("netstats-client")
 
-    if is_bridge_prepared():
+    if is_bridge_prepared(base_dir=base_dir):
         docker_service_names.append("bridge-client")
         docker_service_names.append("mainnet-node")
 
     return docker_service_names
+
+
+def does_docker_compose_file_exist(base_dir):
+    return os.path.isfile(
+        os.path.join(base_dir, "docker-compose.yaml")
+    ) or os.path.isfile(os.path.join(base_dir, "docker-compose.yml"))
+
+
+def copy_default_docker_file(base_dir, docker_compose_file):
+    if not os.path.isfile(docker_compose_file):
+        raise click.ClickException(
+            "\n"
+            + fill(
+                f"Expecting a docker-compose configuration file at {docker_compose_file}"
+            )
+        )
+    shutil.copyfile(docker_compose_file, os.path.join(base_dir, "docker-compose.yaml"))
+
+
+def show_diff(base_dir, docker_compose_file):
+    click.echo("")
+    with open(os.path.join(base_dir, "docker-compose.yaml")) as file:
+        user_lines = file.readlines()
+    with open(docker_compose_file) as file:
+        default_lines = file.readlines()
+
+    is_same = True
+    for line in difflib.unified_diff(
+        user_lines,
+        default_lines,
+        fromfile="Your docker-compose.yaml",
+        tofile="New default docker-compose.yaml",
+        lineterm="",
+    ):
+        is_same = False
+        if len(line) > 1 and line[-1] == "\n":
+            # Remove final newline otherwise we will show two new lines
+            line = line[:-1]
+        if line.startswith("-"):
+            click.secho(line, fg="red")
+        elif line.startswith("+"):
+            click.secho(line, fg="green")
+        else:
+            click.echo(line)
+
+    if is_same:
+        click.echo("Both files are the same")
+
+    click.echo("")

--- a/tools/quickstart/quickstart/monitor.py
+++ b/tools/quickstart/quickstart/monitor.py
@@ -3,11 +3,11 @@ from textwrap import fill
 
 import click
 
-from quickstart.constants import MONITOR_DIR, MONITOR_REPORTS_DIR, MONITOR_STATE_PATH
+from quickstart.constants import MONITOR_DIR, MONITOR_REPORTS_DIR
 from quickstart.utils import is_monitor_prepared
 
 
-def setup_interactively():
+def setup_interactively(base_dir):
     click.echo("\n")
 
     if is_monitor_prepared():
@@ -21,8 +21,7 @@ def setup_interactively():
         )
     )
 
-    os.makedirs(MONITOR_DIR, exist_ok=True)
-    os.makedirs(MONITOR_REPORTS_DIR, exist_ok=True)
-    os.makedirs(os.path.dirname(MONITOR_STATE_PATH), exist_ok=True)
+    os.makedirs(os.path.join(base_dir, MONITOR_DIR), exist_ok=True)
+    os.makedirs(os.path.join(base_dir, MONITOR_REPORTS_DIR), exist_ok=True)
 
     click.echo("Monitor setup complete.")

--- a/tools/quickstart/quickstart/netstats.py
+++ b/tools/quickstart/quickstart/netstats.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 from textwrap import fill
 
@@ -15,8 +16,8 @@ INSTANCE_NAME={instance_name}
 """
 
 
-def setup_interactively() -> None:
-    if is_netstats_prepared():
+def setup_interactively(base_dir) -> None:
+    if is_netstats_prepared(base_dir):
         click.echo("\nThe netstats client has already been set up.")
         return
 
@@ -48,7 +49,7 @@ def setup_interactively() -> None:
         )
     ):
         # Necessary to make docker-compose not complaining about it.
-        Path(NETSTATS_ENV_FILE_PATH).touch()
+        Path(os.path.join(base_dir, NETSTATS_ENV_FILE_PATH)).touch()
         return
 
     while True:
@@ -85,7 +86,7 @@ def setup_interactively() -> None:
 
     instance_name = click.prompt("Instance name")
 
-    with open(NETSTATS_ENV_FILE_PATH, "w") as env_file:
+    with open(os.path.join(base_dir, NETSTATS_ENV_FILE_PATH), "w") as env_file:
         env_file.write(
             ENV_FILE_TEMPLATE.format(
                 username=username, password=password, instance_name=instance_name

--- a/tools/quickstart/quickstart/utils.py
+++ b/tools/quickstart/quickstart/utils.py
@@ -57,16 +57,16 @@ def non_empty_file_exists(file_path: str) -> bool:
     )
 
 
-def is_validator_account_prepared() -> bool:
-    return os.path.isfile(ADDRESS_FILE_PATH)
+def is_validator_account_prepared(base_dir) -> bool:
+    return os.path.isfile(os.path.join(base_dir, ADDRESS_FILE_PATH))
 
 
-def is_netstats_prepared() -> bool:
-    return non_empty_file_exists(NETSTATS_ENV_FILE_PATH)
+def is_netstats_prepared(base_dir) -> bool:
+    return non_empty_file_exists(os.path.join(base_dir, NETSTATS_ENV_FILE_PATH))
 
 
-def is_bridge_prepared() -> bool:
-    return non_empty_file_exists(BRIDGE_CONFIG_FILE_EXTERNAL)
+def is_bridge_prepared(base_dir) -> bool:
+    return non_empty_file_exists(os.path.join(base_dir, BRIDGE_CONFIG_FILE_EXTERNAL))
 
 
 def is_monitor_prepared() -> bool:
@@ -106,7 +106,7 @@ def get_keystore_path() -> str:
             (
                 "Please enter the path to the keystore file to import.",
                 fill(
-                    "If you started the process via the quickstart scipt, please consider that you "
+                    "If you started the process via the quickstart script, please consider that you "
                     "are running within a Docker virtual file system. You can access the current "
                     "working directory via '/data'. (e.g. './my-dir/keystore.json' becomes "
                     "'/data/my-dir/keystore.json')"

--- a/tools/quickstart/quickstart/validator_account.py
+++ b/tools/quickstart/quickstart/validator_account.py
@@ -24,8 +24,8 @@ from quickstart.utils import (
 )
 
 
-def setup_interactively() -> None:
-    if is_validator_account_prepared():
+def setup_interactively(base_dir) -> None:
+    if is_validator_account_prepared(base_dir):
         click.echo("\nA validator account has already been set up.")
         return
     if not prompt_setup_as_validator():
@@ -33,9 +33,9 @@ def setup_interactively() -> None:
 
     ensure_clean_setup()
 
-    os.makedirs(CONFIG_DIR, exist_ok=True)
-    os.makedirs(ENODE_DIR, exist_ok=True)
-    os.makedirs(DATABASE_DIR, exist_ok=True)
+    os.makedirs(os.path.join(base_dir, CONFIG_DIR), exist_ok=True)
+    os.makedirs(os.path.join(base_dir, ENODE_DIR), exist_ok=True)
+    os.makedirs(os.path.join(base_dir, DATABASE_DIR), exist_ok=True)
 
     choice = click.prompt(
         fill(
@@ -48,11 +48,11 @@ def setup_interactively() -> None:
     )
 
     if choice == "1":
-        import_keystore_file()
+        import_keystore_file(base_dir)
     elif choice == "2":
-        import_private_key()
+        import_private_key(base_dir)
     elif choice == "3":
-        generate_new_account()
+        generate_new_account(base_dir)
     else:
         assert False, "unreachable"
 
@@ -73,7 +73,7 @@ def prompt_setup_as_validator():
         assert False, "unreachable"
 
 
-def import_keystore_file() -> None:
+def import_keystore_file(base_dir) -> None:
     click.echo("Starting to import an existing keystore...")
     keystore_path = get_keystore_path()
 
@@ -82,35 +82,41 @@ def import_keystore_file() -> None:
 
     account, password = read_decryption_password(keyfile_dict)
     trustlines_files = TrustlinesFiles(
-        PASSWORD_FILE_PATH, ADDRESS_FILE_PATH, KEYSTORE_FILE_PATH
+        os.path.join(base_dir, PASSWORD_FILE_PATH),
+        os.path.join(base_dir, ADDRESS_FILE_PATH),
+        os.path.join(base_dir, KEYSTORE_FILE_PATH),
     )
     trustlines_files.store(account, password)
 
 
-def import_private_key() -> None:
+def import_private_key(base_dir) -> None:
     click.echo("Starting to import an existing raw private key...")
     private_key = read_private_key()
     account = Account.from_key(private_key)
     password = read_encryption_password()
     trustlines_files = TrustlinesFiles(
-        PASSWORD_FILE_PATH, ADDRESS_FILE_PATH, KEYSTORE_FILE_PATH
+        os.path.join(base_dir, PASSWORD_FILE_PATH),
+        os.path.join(base_dir, ADDRESS_FILE_PATH),
+        os.path.join(base_dir, KEYSTORE_FILE_PATH),
     )
     trustlines_files.store(account, password)
 
 
-def generate_new_account() -> None:
+def generate_new_account(base_dir) -> None:
     click.echo("Starting to generate a new private key...")
     account = Account.create()
     password = read_encryption_password()
     trustlines_files = TrustlinesFiles(
-        PASSWORD_FILE_PATH, ADDRESS_FILE_PATH, KEYSTORE_FILE_PATH
+        os.path.join(base_dir, PASSWORD_FILE_PATH),
+        os.path.join(base_dir, ADDRESS_FILE_PATH),
+        os.path.join(base_dir, KEYSTORE_FILE_PATH),
     )
     trustlines_files.store(account, password)
 
 
-def get_validator_address() -> str:
-    if not is_validator_account_prepared():
+def get_validator_address(base_dir) -> str:
+    if not is_validator_account_prepared(base_dir):
         raise ValueError("Validator account is not prepared! Can not read its address.")
 
-    with open(ADDRESS_FILE_PATH, "r") as address_file:
+    with open(os.path.join(base_dir, ADDRESS_FILE_PATH), "r") as address_file:
         return address_file.read()


### PR DESCRIPTION
This copies the docker-compose file to the host during the quickstart
script. This allows to later change paramters to containers and also the
used images.
This makes the quickstart script configurable based on the
docker-compose file used, you can change the name of the install folder,
and you can change the project name used by docker-compose.
To not just simply override user changes, we give him the chance to show
a diff.