### PR TITLE
Wait for fully synced nodes

### DIFF
--- a/tools/bridge/bridge/events.py
+++ b/tools/bridge/bridge/events.py
@@ -18,6 +18,10 @@ class ChainRole(Enum):
     home = "home"
     foreign = "foreign"
 
+    @property
+    def configuration_key(self):
+        return f"{self.name}_chain"
+
 
 @attr.s(auto_attribs=True)
 class FetcherReachedHeadEvent(Event):

--- a/tools/bridge/bridge/node_status.py
+++ b/tools/bridge/bridge/node_status.py
@@ -1,0 +1,72 @@
+import logging
+from typing import Any, Dict, List
+
+import attr
+import gevent
+import tenacity
+
+logger = logging.getLogger(__name__)
+
+
+@attr.s(auto_attribs=True)
+class NodeStatus:
+    is_parity: bool
+    is_light_node: bool
+    is_syncing: bool
+    syncing_map: Dict
+    block_number: int
+    latest_synced_block: int
+    block_gap: List[int]
+    client_version: Any = attr.ib(repr=False)
+
+
+def get_node_status(w3):
+    client_version = w3.clientVersion
+    is_parity = client_version.startswith("Parity")
+    block_number = w3.eth.blockNumber
+
+    syncing_map = w3.eth.syncing or None
+
+    chain_status = w3.manager.request_blocking("parity_chainStatus", [])
+    node_kind = w3.manager.request_blocking("parity_nodeKind", [])
+
+    if chain_status.blockGap is not None:
+        block_gap = [int(x, 16) for x in chain_status.blockGap]
+    else:
+        block_gap = None
+
+    is_light_node = node_kind.capability == "light"
+
+    if block_gap and not is_light_node:  # warp mode syncing
+        is_syncing = True
+        latest_synced_block = block_gap[0]
+    elif syncing_map:
+        is_syncing = True
+        latest_synced_block = syncing_map.currentBlock
+    else:
+        is_syncing = False
+        latest_synced_block = block_number
+
+    return NodeStatus(
+        is_parity=is_parity,
+        is_light_node=is_light_node,
+        is_syncing=is_syncing,
+        syncing_map=syncing_map,
+        block_gap=block_gap,
+        block_number=block_number,
+        latest_synced_block=latest_synced_block,
+        client_version=client_version,
+    )
+
+
+def wait_for_node_status(w3, predicate, sleep_time=5.0):
+    retry = tenacity.retry(
+        wait=tenacity.wait_exponential(multiplier=1, min=5, max=120),
+        before_sleep=tenacity.before_sleep_log(logger, logging.WARN),
+    )
+    while True:
+        node_status = retry(get_node_status)(w3)
+        logger.debug("wait_for_node_status, current status: %s", node_status)
+        if predicate(node_status):
+            return node_status
+        gevent.sleep(sleep_time)

--- a/tools/bridge/bridge/node_status.py
+++ b/tools/bridge/bridge/node_status.py
@@ -39,7 +39,7 @@ def get_node_status(w3):
 
     if block_gap and not is_light_node:  # warp mode syncing
         is_syncing = True
-        latest_synced_block = block_gap[0]
+        latest_synced_block = block_gap[0] - 1
     elif syncing_map:
         is_syncing = True
         latest_synced_block = syncing_map.currentBlock
@@ -59,14 +59,13 @@ def get_node_status(w3):
     )
 
 
-def wait_for_node_status(w3, predicate, sleep_time=5.0):
+def wait_for_node_status(w3, predicate, sleep_time=30.0):
     retry = tenacity.retry(
         wait=tenacity.wait_exponential(multiplier=1, min=5, max=120),
         before_sleep=tenacity.before_sleep_log(logger, logging.WARN),
     )
     while True:
         node_status = retry(get_node_status)(w3)
-        logger.debug("wait_for_node_status, current status: %s", node_status)
         if predicate(node_status):
             return node_status
         gevent.sleep(sleep_time)


### PR DESCRIPTION
This is based on #485, please only review the last two commits.

Wait for home and foreign node to be fully synced

We decided that it might be safer to wait until both nodes are fully
synced.

There are two additional advantages:

1. We do not run into an error when we ask for a contracts code in
order to do our sanity checks.
(see https://github.com/trustlines-protocol/blockchain/issues/452)

2. We prevent the problem with warp-syncing which has a gap of blocks
for which parity does only deliver empty results when we ask for
events.
(see https://github.com/trustlines-protocol/blockchain/issues/473)

The code has been refactored and cleaned up a bit. We now use
bridge.node_status module.

This supersedes PR #459