### PR TITLE
Add release tags to all images

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -6,7 +6,7 @@
 version: "2.4"
 services:
   trustlines-node:
-    image: trustlines/tlbc-testnet
+    image: trustlines/tlbc-testnet:release
     restart: always
     stop_grace_period: 3m
     networks:
@@ -60,7 +60,7 @@ services:
       --no-color
 
   netstats-client:
-    image: trustlines/netstats-client:master
+    image: trustlines/netstats-client:release
     restart: always
     env_file: ./trustlines/netstats-env
     environment:
@@ -71,7 +71,7 @@ services:
       - trustlines-node
 
   bridge-client:
-    image: trustlines/bridge-next:master # TODO: switch to 'bridge:latest'
+    image: trustlines/bridge-next:release
     restart: always
     mem_limit: 512M
     mem_reservation: 16M
@@ -88,7 +88,7 @@ services:
     command: -c /config/config.toml
 
   tlbc-monitor:
-    image: trustlines/tlbc-monitor:latest  # TODO: switch to master?
+    image: trustlines/tlbc-monitor:release
     restart: always
     mem_limit: 512M
     mem_reservation: 16M


### PR DESCRIPTION
Doesn't work yet because some of the tags don't exist yet.

Also added on to the tlbc-testnet image for consistency (as far as I can tell it shouldn't make a difference, at least latest == release right now at docker hub).