### PR TITLE
Fix include of package data in quickstart

### DIFF
--- a/tools/quickstart/setup.cfg
+++ b/tools/quickstart/setup.cfg
@@ -10,7 +10,9 @@ install_requires =
   requests
   toml
 packages = quickstart
-package-data.quickstart = configs/*
+[options.package_data]
+quickstart =
+  configs/**
 
 [options.entry_points]
 console_scripts=


### PR DESCRIPTION
The package data was before not actually included. 