### PR TITLE
Explicitly select docker containers to update

### DIFF
--- a/tools/quickstart/quickstart/configs/laika/docker-compose.yaml
+++ b/tools/quickstart/quickstart/configs/laika/docker-compose.yaml
@@ -9,6 +9,8 @@ services:
     image: trustlines/tlbc-testnet:release
     restart: always
     stop_grace_period: 3m
+    labels:
+      com.centurylinklabs.watchtower.enable: "true"
     networks:
       home-net:
         aliases:
@@ -34,6 +36,8 @@ services:
     # Root access is required here, because the trustlines node
     # use the same database volume and does not run as 'parity' user
     user: root
+    labels:
+      com.centurylinklabs.watchtower.enable: "true"
     networks:
       - foreign-net
     volumes:
@@ -56,6 +60,8 @@ services:
     env_file: ./netstats-env
     environment:
       - RPC_HOST=home-node
+    labels:
+      com.centurylinklabs.watchtower.enable: "true"
     networks:
       - home-net
     depends_on:
@@ -73,6 +79,8 @@ services:
     volumes:
       - ${HOST_BASE_DIR:-.}/config:/config
       - ${HOST_BASE_DIR:-.}/bridge-config.toml:/config.toml
+    labels:
+      com.centurylinklabs.watchtower.enable: "true"
     depends_on:
       - home-node
       - foreign-node
@@ -84,6 +92,8 @@ services:
     mem_limit: 512M
     mem_reservation: 16M
     stop_grace_period: 30s
+    labels:
+      com.centurylinklabs.watchtower.enable: "true"
     networks:
       - home-net
     volumes:
@@ -102,7 +112,7 @@ services:
     networks:
       - home-net
       - foreign-net
-    command: --api-version 1.25
+    command: --api-version 1.25 --label-enable
 
 networks:
   home-net:

--- a/tools/quickstart/quickstart/configs/tlbc/docker-compose.yaml
+++ b/tools/quickstart/quickstart/configs/tlbc/docker-compose.yaml
@@ -9,6 +9,8 @@ services:
     image: trustlines/tlbc:release
     restart: always
     stop_grace_period: 3m
+    labels:
+      com.centurylinklabs.watchtower.enable: "true"
     networks:
       home-net:
         aliases:
@@ -34,6 +36,8 @@ services:
     # Root access is required here, because the trustlines node
     # use the same database volume and does not run as 'parity' user
     user: root
+    labels:
+      com.centurylinklabs.watchtower.enable: "true"
     networks:
       - foreign-net
     volumes:
@@ -60,6 +64,8 @@ services:
     env_file: ./netstats-env
     environment:
       - RPC_HOST=home-node
+    labels:
+      com.centurylinklabs.watchtower.enable: "true"
     networks:
       - home-net
     depends_on:
@@ -77,6 +83,8 @@ services:
     volumes:
       - ${HOST_BASE_DIR:-.}/config:/config
       - ${HOST_BASE_DIR:-.}/bridge-config.toml:/config.toml
+    labels:
+      com.centurylinklabs.watchtower.enable: "true"
     depends_on:
       - home-node
       - foreign-node
@@ -88,6 +96,8 @@ services:
     mem_limit: 512M
     mem_reservation: 16M
     stop_grace_period: 30s
+    labels:
+      com.centurylinklabs.watchtower.enable: "true"
     networks:
       - home-net
     volumes:
@@ -106,7 +116,7 @@ services:
     networks:
       - home-net
       - foreign-net
-    command: --api-version 1.25
+    command: --api-version 1.25 --label-enable
 
 networks:
   home-net:


### PR DESCRIPTION
Fixes #502

For testing, I have run the quickstart script for Laika and checked that all services start up and that the labels are set correctly. I have not waited for an update though. Given that the change is rather small I think this is OK, let me know if you disagree.

Links to docs I consulted: https://containrrr.github.io/watchtower/container-selection/ and https://docs.docker.com/compose/compose-file/