### PR TITLE
Override old bridge config in quickstart

### DIFF
--- a/tools/quickstart/quickstart/bridge.py
+++ b/tools/quickstart/quickstart/bridge.py
@@ -1,3 +1,4 @@
+import filecmp
 import os
 import shutil
 from pathlib import Path
@@ -6,13 +7,32 @@ from textwrap import fill
 import click
 
 from quickstart.constants import BRIDGE_CONFIG_FILE_EXTERNAL, BRIDGE_DOCUMENTATION_URL
-from quickstart.utils import is_bridge_prepared, is_validator_account_prepared
+from quickstart.utils import (
+    file_hash,
+    is_bridge_prepared,
+    is_validator_account_prepared,
+    show_file_diff,
+)
+
+# List of hashes of former default bridge configs
+LEGACY_CONFIG_HASHES = ["15dda4731c857ff978141e583c5e995727fb0284"]
 
 
 def setup_interactively(base_dir, bridge_config_file) -> None:
+    user_file = os.path.join(base_dir, BRIDGE_CONFIG_FILE_EXTERNAL)
     if is_bridge_prepared(base_dir):
         click.echo("\nThe bridge client has already been set up.")
+        if file_hash(user_file) in LEGACY_CONFIG_HASHES:
+            # Override former config files without asking
+            copy_default_bridge_config(base_dir, bridge_config_file)
+        elif filecmp.cmp(user_file, bridge_config_file):
+            # same file, so nothing to do
+            pass
+        else:
+            # Custom changes
+            _show_file_override_dialog(base_dir, bridge_config_file)
         return
+
     if not is_validator_account_prepared(base_dir):
         click.echo("\nNo bridge node will be set up as running as a non-validator.")
         return
@@ -34,10 +54,44 @@ def setup_interactively(base_dir, bridge_config_file) -> None:
         "Do you want to set up a bridge node now? (recommended)", default=True
     ):
         # Necessary to make docker-compose not complain about it.
-        Path(os.path.join(base_dir, BRIDGE_CONFIG_FILE_EXTERNAL)).touch()
+        Path(user_file).touch()
         return
 
+    copy_default_bridge_config(base_dir, bridge_config_file)
+
+    click.echo("Bridge client setup complete.")
+
+
+def copy_default_bridge_config(base_dir, bridge_config_file):
     shutil.copyfile(
         bridge_config_file, os.path.join(base_dir, BRIDGE_CONFIG_FILE_EXTERNAL)
     )
-    click.echo("Bridge client setup complete.")
+
+
+def _show_file_override_dialog(base_dir, bridge_config_file):
+    while True:
+        choice = click.prompt(
+            fill(
+                "You already seem to have a bridge config file. "
+                "If you did not change it, you can safely override it.\n"
+                "Override with default (1), keep own (2), or show diff (3) ?"
+            )
+            + "\n",
+            type=click.Choice(("1", "2", "3")),
+            show_choices=False,
+        )
+
+        if choice == "1":
+            copy_default_bridge_config(base_dir, bridge_config_file)
+            break
+        elif choice == "2":
+            # Nothing to do
+            break
+        elif choice == "3":
+            show_file_diff(
+                os.path.join(base_dir, BRIDGE_CONFIG_FILE_EXTERNAL),
+                bridge_config_file,
+                file_name=BRIDGE_CONFIG_FILE_EXTERNAL,
+            )
+        else:
+            assert False, "unreachable"

--- a/tools/quickstart/quickstart/docker.py
+++ b/tools/quickstart/quickstart/docker.py
@@ -1,4 +1,3 @@
-import difflib
 import filecmp
 import os
 import shutil
@@ -14,6 +13,7 @@ from quickstart.utils import (
     is_bridge_prepared,
     is_netstats_prepared,
     is_validator_account_prepared,
+    show_file_diff,
 )
 from quickstart.validator_account import get_validator_address
 
@@ -196,32 +196,8 @@ def copy_default_docker_file(base_dir, docker_compose_file):
 
 
 def show_diff(base_dir, docker_compose_file):
-    click.echo("")
-    with open(os.path.join(base_dir, DOCKER_COMPOSE_FILE_NAME)) as file:
-        user_lines = file.readlines()
-    with open(docker_compose_file) as file:
-        default_lines = file.readlines()
-
-    is_same = True
-    for line in difflib.unified_diff(
-        user_lines,
-        default_lines,
-        fromfile=f"Your {DOCKER_COMPOSE_FILE_NAME}",
-        tofile=f"New default {DOCKER_COMPOSE_FILE_NAME}",
-        lineterm="",
-    ):
-        is_same = False
-        if len(line) > 1 and line[-1] == "\n":
-            # Remove final newline otherwise we will show two new lines
-            line = line[:-1]
-        if line.startswith("-"):
-            click.secho(line, fg="red")
-        elif line.startswith("+"):
-            click.secho(line, fg="green")
-        else:
-            click.echo(line)
-
-    if is_same:
-        click.echo("Both files are the same")
-
-    click.echo("")
+    show_file_diff(
+        os.path.join(base_dir, DOCKER_COMPOSE_FILE_NAME),
+        docker_compose_file,
+        file_name=DOCKER_COMPOSE_FILE_NAME,
+    )


### PR DESCRIPTION
Fixes that old bridge configs were not ovewritten. To not annoy the
user to much, we only ask him it if something changed, and if the old config is
not one of the former default configs.