### PR TITLE
Use release docker images for tlbc quickstart

### DIFF
--- a/tools/quickstart/quickstart/configs/tlbc/docker-compose.yaml
+++ b/tools/quickstart/quickstart/configs/tlbc/docker-compose.yaml
@@ -6,7 +6,7 @@
 version: "2.4"
 services:
   home-node:
-    image: trustlines/tlbc:release
+    image: trustlines/tlbc-node:release
     restart: always
     stop_grace_period: 3m
     labels:
@@ -72,7 +72,7 @@ services:
       - home-node
 
   bridge-client:
-    image: trustlines/bridge-release
+    image: trustlines/bridge:release
     restart: always
     mem_limit: 512M
     mem_reservation: 16M

--- a/tools/quickstart/quickstart/configs/tlbc/docker-compose.yaml
+++ b/tools/quickstart/quickstart/configs/tlbc/docker-compose.yaml
@@ -6,7 +6,7 @@
 version: "2.4"
 services:
   home-node:
-    image: trustlines/tlbc-node:release
+    image: trustlines/tlbc-node-next:master
     restart: always
     stop_grace_period: 3m
     labels:


### PR DESCRIPTION
**Note:** the quickstart for the `tlbc` network will not work for the moment, since there is no `tlbc-node:release` image so far. This must be provided in future when the setup is ready.

Closes: #464