### PR TITLE
Fix wrong pathname for key in quickstart

### DIFF
--- a/tools/quickstart/quickstart/cli.py
+++ b/tools/quickstart/quickstart/cli.py
@@ -104,6 +104,7 @@ def tlbc(host_base_dir, project_name, base_dir):
         host_base_dir=host_base_dir,
         project_name=project_name,
         base_dir=base_dir,
+        chain_dir="tlbc",
     )
 
 
@@ -128,6 +129,7 @@ def laika(host_base_dir, project_name, base_dir):
         host_base_dir=host_base_dir,
         project_name=project_name,
         base_dir=base_dir,
+        chain_dir="Trustlines",
     )
 
 
@@ -164,6 +166,11 @@ def laika(host_base_dir, project_name, base_dir):
     default=None,
     metavar="URL",
 )
+@click.option(
+    "--chain-dir",
+    help="The chain directory name as specified in the chain spec file.",
+    default="Trustlines",
+)
 @project_name_option(default="custom")
 @base_dir_option(default="custom")
 @host_base_dir_option
@@ -174,6 +181,7 @@ def custom(
     project_name,
     bridge_config,
     netstats_url,
+    chain_dir,
 ):
     """
     Setup with custom settings.
@@ -189,6 +197,7 @@ def custom(
     run(
         "custom blockchain node",
         base_dir=base_dir,
+        chain_dir=chain_dir,
         bridge_config_file=bridge_config,
         docker_compose_file=docker_compose_file,
         netstats_url=netstats_url,
@@ -204,6 +213,7 @@ def run(
     docker_compose_file,
     base_dir,
     project_name,
+    chain_dir,
     netstats_url=None,
     host_base_dir=None,
 ):
@@ -224,7 +234,7 @@ def run(
             )
         )
     )
-    validator_account.setup_interactively(base_dir=base_dir)
+    validator_account.setup_interactively(base_dir=base_dir, chain_dir=chain_dir)
     monitor.setup_interactively(base_dir=base_dir)
     bridge.setup_interactively(base_dir=base_dir, bridge_config_file=bridge_config_file)
     netstats.setup_interactively(base_dir=base_dir, netstats_url=netstats_url)

--- a/tools/quickstart/quickstart/configs/tlbc/bridge-config.toml
+++ b/tools/quickstart/quickstart/configs/tlbc/bridge-config.toml
@@ -10,5 +10,5 @@ bridge_contract_address = "0x0000000000000000000000000000000000000401"
 event_fetch_start_block_number = 0
 
 [validator_private_key]
-keystore_path = "/config/keys/TLBC/account.json"
+keystore_path = "/config/keys/tlbc/account.json"
 keystore_password_path = "/config/pass.pwd"

--- a/tools/quickstart/quickstart/configs/tlbc/docker-compose.yaml
+++ b/tools/quickstart/quickstart/configs/tlbc/docker-compose.yaml
@@ -19,7 +19,7 @@ services:
       - 30300:30300
       - 30300:30300/udp
     volumes:
-      - ${HOST_BASE_DIR:-.}/databases:/data
+      - ${HOST_BASE_DIR:-.}/databases/home-node:/data/tlbc
       - ${HOST_BASE_DIR:-.}/config:/config/custom
       - ${HOST_BASE_DIR:-.}/enode:/config/network
       - ${HOST_BASE_DIR:-.}/shared:/shared/

--- a/tools/quickstart/quickstart/constants.py
+++ b/tools/quickstart/quickstart/constants.py
@@ -3,12 +3,11 @@ import os
 CONFIG_DIR = "config"
 ENODE_DIR = "enode"
 DATABASE_DIR = "databases"
-KEY_DIR = os.path.join(CONFIG_DIR, "keys", "Trustlines")
+KEY_DIR = os.path.join(CONFIG_DIR, "keys")
 
 KEYSTORE_FILE_NAME = "account.json"
 PASSWORD_FILE_NAME = "pass.pwd"
 
-KEYSTORE_FILE_PATH = os.path.join(KEY_DIR, KEYSTORE_FILE_NAME)
 PASSWORD_FILE_PATH = os.path.join(CONFIG_DIR, PASSWORD_FILE_NAME)
 ADDRESS_FILE_PATH = os.path.join(CONFIG_DIR, "address")
 

--- a/tools/quickstart/quickstart/utils.py
+++ b/tools/quickstart/quickstart/utils.py
@@ -14,14 +14,15 @@ from eth_utils import decode_hex, is_hex, remove_0x_prefix
 from quickstart.constants import (
     ADDRESS_FILE_PATH,
     BRIDGE_CONFIG_FILE_EXTERNAL,
-    KEYSTORE_FILE_PATH,
+    KEY_DIR,
+    KEYSTORE_FILE_NAME,
     MONITOR_DIR,
     NETSTATS_ENV_FILE_PATH,
     PASSWORD_FILE_PATH,
 )
 
 
-def ensure_clean_setup(base_dir):
+def ensure_clean_setup(base_dir, chain_dir):
     if os.path.isfile(os.path.join(base_dir, PASSWORD_FILE_PATH)):
         raise click.ClickException(
             "\n".join(
@@ -31,7 +32,7 @@ def ensure_clean_setup(base_dir):
                 )
             )
         )
-    if os.path.isfile(os.path.join(base_dir, KEYSTORE_FILE_PATH)):
+    if os.path.isfile(os.path.join(base_dir, KEY_DIR, chain_dir, KEYSTORE_FILE_NAME)):
         raise click.ClickException(
             "\n".join(
                 (

--- a/tools/quickstart/quickstart/validator_account.py
+++ b/tools/quickstart/quickstart/validator_account.py
@@ -10,7 +10,8 @@ from quickstart.constants import (
     CONFIG_DIR,
     DATABASE_DIR,
     ENODE_DIR,
-    KEYSTORE_FILE_PATH,
+    KEY_DIR,
+    KEYSTORE_FILE_NAME,
     PASSWORD_FILE_PATH,
 )
 from quickstart.utils import (
@@ -24,14 +25,14 @@ from quickstart.utils import (
 )
 
 
-def setup_interactively(base_dir) -> None:
+def setup_interactively(base_dir, chain_dir) -> None:
     if is_validator_account_prepared(base_dir):
         click.echo("\nA validator account has already been set up.")
         return
     if not prompt_setup_as_validator():
         return
 
-    ensure_clean_setup(base_dir)
+    ensure_clean_setup(base_dir, chain_dir)
 
     os.makedirs(os.path.join(base_dir, CONFIG_DIR), exist_ok=True)
     os.makedirs(os.path.join(base_dir, ENODE_DIR), exist_ok=True)
@@ -48,11 +49,11 @@ def setup_interactively(base_dir) -> None:
     )
 
     if choice == "1":
-        import_keystore_file(base_dir)
+        import_keystore_file(base_dir, chain_dir)
     elif choice == "2":
-        import_private_key(base_dir)
+        import_private_key(base_dir, chain_dir)
     elif choice == "3":
-        generate_new_account(base_dir)
+        generate_new_account(base_dir, chain_dir)
     else:
         assert False, "unreachable"
 
@@ -73,7 +74,7 @@ def prompt_setup_as_validator():
         assert False, "unreachable"
 
 
-def import_keystore_file(base_dir) -> None:
+def import_keystore_file(base_dir, chain_dir) -> None:
     click.echo("Starting to import an existing keystore...")
     keystore_path = get_keystore_path()
 
@@ -84,12 +85,12 @@ def import_keystore_file(base_dir) -> None:
     trustlines_files = TrustlinesFiles(
         os.path.join(base_dir, PASSWORD_FILE_PATH),
         os.path.join(base_dir, ADDRESS_FILE_PATH),
-        os.path.join(base_dir, KEYSTORE_FILE_PATH),
+        os.path.join(base_dir, KEY_DIR, chain_dir, KEYSTORE_FILE_NAME),
     )
     trustlines_files.store(account, password)
 
 
-def import_private_key(base_dir) -> None:
+def import_private_key(base_dir, chain_dir) -> None:
     click.echo("Starting to import an existing raw private key...")
     private_key = read_private_key()
     account = Account.from_key(private_key)
@@ -97,19 +98,19 @@ def import_private_key(base_dir) -> None:
     trustlines_files = TrustlinesFiles(
         os.path.join(base_dir, PASSWORD_FILE_PATH),
         os.path.join(base_dir, ADDRESS_FILE_PATH),
-        os.path.join(base_dir, KEYSTORE_FILE_PATH),
+        os.path.join(base_dir, KEY_DIR, chain_dir, KEYSTORE_FILE_NAME),
     )
     trustlines_files.store(account, password)
 
 
-def generate_new_account(base_dir) -> None:
+def generate_new_account(base_dir, chain_dir) -> None:
     click.echo("Starting to generate a new private key...")
     account = Account.create()
     password = read_encryption_password()
     trustlines_files = TrustlinesFiles(
         os.path.join(base_dir, PASSWORD_FILE_PATH),
         os.path.join(base_dir, ADDRESS_FILE_PATH),
-        os.path.join(base_dir, KEYSTORE_FILE_PATH),
+        os.path.join(base_dir, KEY_DIR, chain_dir, KEYSTORE_FILE_NAME),
     )
     trustlines_files.store(account, password)
 


### PR DESCRIPTION
The quickstart script used a hard coded name. This does not work now
that we have two chains.