### PR TITLE
Set foreign node to goerli for tlbc setup

### DIFF
--- a/tools/quickstart/quickstart/configs/tlbc/bridge-config.toml
+++ b/tools/quickstart/quickstart/configs/tlbc/bridge-config.toml
@@ -1,8 +1,8 @@
 [foreign_chain]
 rpc_url = "http://foreign-node:8545"
-token_contract_address = "0x0000000000000000000000000000000000000000"
-bridge_contract_address = "0x0000000000000000000000000000000000000000"
-event_fetch_start_block_number = 99999999999999999
+token_contract_address = "0x54B06531214AD41DE9d771c10C0030d048d0cC67"
+bridge_contract_address = "0x2171Dd4d4F6ca30FeEA8a27b96257A67f371d87A"
+event_fetch_start_block_number = 1321331
 
 [home_chain]
 rpc_url = "http://home-node:8545"

--- a/tools/quickstart/quickstart/configs/tlbc/docker-compose.yaml
+++ b/tools/quickstart/quickstart/configs/tlbc/docker-compose.yaml
@@ -28,7 +28,7 @@ services:
       --address ${VALIDATOR_ADDRESS}
 
   foreign-node:
-    image: parity/parity:stable
+    image: ethereum/client-go:stable
     restart: always
     mem_limit: 1G
     mem_reservation: 16M
@@ -44,19 +44,15 @@ services:
       # Need to adjust the path if using different chain
       - ${HOST_BASE_DIR:-.}/databases/foreign-node:/data/database
     command: >-
-      --light
-      --no-download
-      --auto-update none
-      --db-path /data/database
-      --base-path /data
-      --no-hardware-wallets
-      --jsonrpc-interface all
-      --jsonrpc-apis safe
-      --jsonrpc-hosts all
-      --jsonrpc-cors all
-      --no-ipc
-      --no-secretstore
-      --no-color
+      --rpc
+      --rpcaddr 0.0.0.0
+      --nousb
+      --ipcdisable
+      --goerli
+      --syncmode light
+      --datadir /data/database
+      --rpccorsdomain *
+      --rpcvhosts=*
 
   netstats-client:
     image: trustlines/netstats-client:release


### PR DESCRIPTION
Set the foreign node to goerli for now, to be able to test the
blockchainstart.