### PR TITLE
Write release process for blockchain images

### DIFF
--- a/chain/README-dev.md
+++ b/chain/README-dev.md
@@ -1,0 +1,32 @@
+# Developer Documentation
+
+## Release Checklist
+
+0. Prerequsisite: The master branch contains the version to be
+   released
+1. Open and merge a PR `master` -> `laika-node/pre-release` (for
+   testnet releases) or `master` -> `tlbc-node/pre-release` (for
+   mainnet releases) without waiting for a review. This will built
+   the docker image and push it to Docker Hub under either
+   `trustlines/tlbc-testnet-next:pre-release` (for testnet
+   releases) or `trustlines/tlbc-node-next:pre-release` (for mainnet
+   releases).
+2. Test the pre-release:
+   - Pull the newly built image from Docker Hub.
+   - Double check that changes to the chain spec (if any) are
+     correct.
+   - Run the node and check that it finds other peers, connects to
+     them, and starts syncing the chain.
+   - Run the node in a pre-existing environment set up using the
+     quickstart script and check that it connects to peers and
+     continues to stay at the head of the chain.
+   - Perform any additional tests compelled by the specifics of the
+     update.
+3. Open a PR `laika-node/pre-release` -> `laika-node/release` or
+   `tlbc-node/pre-release` -> `tlbc-node/release`, wait for a review
+   confirming that the necessary testing steps have been performed,
+   and merge it.
+4. Authorize the release in CircleCI
+5. Check that the image is built and pushed to Docker Hub under
+   `trustlines/tlbc-testnet:release` or
+   `trustlines/tlbc-node:release`, respectively.

--- a/tools/bridge/README-dev.md
+++ b/tools/bridge/README-dev.md
@@ -62,9 +62,9 @@ master branch with `bumpversion patch`.
 
 0. Prerequsisite: The master branch contains the version to be
    released
-1. Open and merge a PR master -> pre-release (no review needed). This
-   will built the docker image and push it to Docker Hub under
-   `trustlines/bridge-next:pre-release`.
+1. Open and merge a PR `master` -> `bridge/pre-release` (no review
+   needed). This will built the docker image and push it to Docker
+   Hub under `trustlines/bridge-next:pre-release`.
 2. Test the pre-release:
    - Pull the newly built image from Docker Hub.
    - Run the bridge worker and connected to a home and foreign chain
@@ -75,8 +75,9 @@ master branch with `bumpversion patch`.
      starts to sync properly.
    - Perform any additional tests compelled by the specifics of the
      update.
-3. Open a PR pre-release -> release, wait for a review confirming
-   that the necessary testing steps have been performed, and merge it.
+3. Open a PR `bridge/pre-release` -> `bridge/release`, wait for a
+   review confirming that the necessary testing steps have been
+   performed, and merge it.
 4. Authorize the release in CircleCI
 5. Check that the image is built and pushed to Docker Hub under
    `trustlines/bridge:release`.


### PR DESCRIPTION
Very similar to the [one for the bridge](https://github.com/trustlines-protocol/blockchain/blob/master/tools/bridge/README-dev.md#release-checklist).

I've also clarified/fixed the branch names in the bridge release process description (add `bridge/` prefix) to distinguish from the ones for the blockchain.