### PR TITLE
Separate port for tlbc image

### DIFF
--- a/chain/tlbc/Dockerfile
+++ b/chain/tlbc/Dockerfile
@@ -27,7 +27,7 @@ RUN chmod 755 $PARITY_BIN
 
 ## Configuring
 ### Network RPC WebSocket SecretStore IPFS
-EXPOSE 30300 8545 8546 8082 5001
+EXPOSE 30302 8545 8546 8082 5001
 
 ### Default chain and node configuration files.
 COPY ./tlbc/tlbc-spec.json $PARITY_CONFIG_FILE_CHAIN

--- a/tools/quickstart/quickstart/configs/tlbc/docker-compose.yaml
+++ b/tools/quickstart/quickstart/configs/tlbc/docker-compose.yaml
@@ -16,8 +16,8 @@ services:
         aliases:
           - home-node
     ports:
-      - 30300:30300
-      - 30300:30300/udp
+      - 30302:30302
+      - 30302:30302/udp
     volumes:
       - ${HOST_BASE_DIR:-.}/databases/home-node:/data/tlbc
       - ${HOST_BASE_DIR:-.}/config:/config/custom


### PR DESCRIPTION
Based on the split config pr, so merge that first. 
Only last commit is relevant. 

Set different port 30302 for tlbc chain. 
This will most likely break the current boot nodes, if they autoupdate. 