### PR TITLE
Fix check_credentials when using the new tlbc netstats setup

### DIFF
--- a/tools/quickstart/quickstart/netstats.py
+++ b/tools/quickstart/quickstart/netstats.py
@@ -101,6 +101,6 @@ def setup_interactively(base_dir, netstats_url) -> None:
 
 
 def check_credentials(netstats_url, username: str, password: str) -> bool:
-    url = f"{netstats_url}/check"
+    url = f"{netstats_url}/check/"
     response = requests.get(url, auth=(username, password), timeout=10.0)
     return response.status_code == 200


### PR DESCRIPTION
I'm not sure about the reason why we now need a slash at the end of
the /check/ URL. Anyway, it makes the check work with the new
setup. And it still works for the old laika setup.