### PR TITLE
WIP: Handle legacy validator key files of format UTC-*

### DIFF
--- a/tools/quickstart/quickstart/cli.py
+++ b/tools/quickstart/quickstart/cli.py
@@ -237,6 +237,7 @@ def run(
                 ),
             )
         )
+        + "\n"
     )
     validator_account.setup_interactively(base_dir=base_dir, chain_dir=chain_dir)
     validator_account.setup_author_address(setup_name=setup_name, base_dir=base_dir)

--- a/tools/quickstart/quickstart/cli.py
+++ b/tools/quickstart/quickstart/cli.py
@@ -235,9 +235,9 @@ def run(
                     "restarted and no configuration will be overwritten. It is possible to enable "
                     "additional components that you have chosen not to configure in earlier runs."
                 ),
+                "",
             )
         )
-        + "\n"
     )
     validator_account.setup_interactively(base_dir=base_dir, chain_dir=chain_dir)
     validator_account.setup_author_address(setup_name=setup_name, base_dir=base_dir)

--- a/tools/quickstart/quickstart/constants.py
+++ b/tools/quickstart/quickstart/constants.py
@@ -6,6 +6,7 @@ DATABASE_DIR = "databases"
 KEY_DIR = os.path.join(CONFIG_DIR, "keys")
 
 KEYSTORE_FILE_NAME = "account.json"
+LEGACY_KEYSTORE_FILE_NAME_PATTERN = "UTC-*"
 PASSWORD_FILE_NAME = "pass.pwd"
 
 PASSWORD_FILE_PATH = os.path.join(CONFIG_DIR, PASSWORD_FILE_NAME)

--- a/tools/quickstart/quickstart/validator_account.py
+++ b/tools/quickstart/quickstart/validator_account.py
@@ -178,24 +178,23 @@ def get_author_address(base_dir) -> str:
 
 
 def handle_legacy_validator_key_file(base_dir, chain_dir):
-    legacy_key_file_paths = legacy_validator_key_paths(base_dir, chain_dir)
-    key_file_paths = legacy_key_file_paths.copy()
     if validator_key_file_exists(base_dir, chain_dir):
-        key_file_paths.append(validator_key_file_path(base_dir, chain_dir))
+        return
 
-    if len(key_file_paths) > 1:
+    legacy_key_file_paths = legacy_validator_key_paths(base_dir, chain_dir)
+    if len(legacy_key_file_paths) > 1:
         error_message = fill(
-            f"There are multiple files that correspond to validator keys: {key_file_paths}. "
-            f"Please make sure there is at most one key file in {os.path.join(base_dir, KEY_DIR, chain_dir)} "
-            f"and restart the quickstart."
+            f"There are multiple files that correspond to validator keys: {legacy_key_file_paths}. "
+            f"Please make sure there is one key file in {os.path.join(base_dir, KEY_DIR, chain_dir)} "
+            f"named 'account.json', so we know which one to select for the bridge."
         )
         raise click.exceptions.UsageError(error_message)
     elif len(legacy_key_file_paths) == 1:
         try:
-            rename_legacy_key_file(base_dir, chain_dir, key_file_paths[0])
+            rename_legacy_key_file(base_dir, chain_dir, legacy_key_file_paths[0])
         except PermissionError:
             error_message = fill(
-                f"The validator key file {key_file_paths[0]} cannot be accessed, "
+                f"The validator key file {legacy_key_file_paths[0]} cannot be accessed, "
                 f"please change the permissions of the file."
             )
             raise click.exceptions.UsageError(error_message)

--- a/tools/quickstart/quickstart/validator_account.py
+++ b/tools/quickstart/quickstart/validator_account.py
@@ -191,7 +191,14 @@ def handle_legacy_validator_key_file(base_dir, chain_dir):
         )
         raise click.exceptions.UsageError(error_message)
     elif len(legacy_key_file_paths) == 1:
-        rename_legacy_key_file(base_dir, chain_dir, key_file_paths[0])
+        try:
+            rename_legacy_key_file(base_dir, chain_dir, key_file_paths[0])
+        except PermissionError:
+            error_message = fill(
+                f"The validator key file {key_file_paths[0]} cannot be accessed, "
+                f"please change the permissions of the file."
+            )
+            raise click.exceptions.UsageError(error_message)
 
 
 def validator_key_file_exists(base_dir, chain_dir):


### PR DESCRIPTION
Handle legacy validator key files of format UTC-* by renaming them "account.json"

related: https://github.com/trustlines-protocol/blockchain/issues/556

If I run the quickstart with an old master commit (I randomly took https://github.com/trustlines-protocol/blockchain/commit/754cd7918d9e19c70154690e18e0728ce4c63cc0), and then run it with this branch, I get a permission denied error as quickstart cannot rename the legacy key file. Have to find another way.