### PR TITLE
Make tlbc netstats client report to the tlbc netstats server

### DIFF
--- a/tools/quickstart/quickstart/configs/tlbc/docker-compose.yaml
+++ b/tools/quickstart/quickstart/configs/tlbc/docker-compose.yaml
@@ -62,6 +62,7 @@ services:
     env_file: ./netstats-env
     environment:
       - RPC_HOST=home-node
+      - WS_HOST=netstats.tlbc.trustlines.foundation
     labels:
       com.centurylinklabs.watchtower.enable: "true"
     networks:


### PR DESCRIPTION
i.e. report to https://netstats.tlbc.trustlines.foundation/