### PR TITLE
Reduce foreign node requests to work better with hosted nodes

### DIFF
--- a/tools/bridge/bridge/config.py
+++ b/tools/bridge/bridge/config.py
@@ -116,7 +116,7 @@ class ChainSchema(Schema):
     rpc_timeout = fields.Integer(missing=180, validate=validate_non_negative)
     bridge_contract_address = AddressField(required=True)
     max_reorg_depth = fields.Integer(validate=validate_non_negative)
-    event_poll_interval = fields.Float(missing=5, validate=validate_non_negative)
+    event_poll_interval = fields.Float(validate=validate_non_negative)
     event_fetch_start_block_number = fields.Integer(
         missing=0, validate=validate_non_negative
     )
@@ -124,17 +124,18 @@ class ChainSchema(Schema):
 
 class ForeignChainSchema(ChainSchema):
     max_reorg_depth = fields.Integer(missing=10, validate=validate_non_negative)
+    event_poll_interval = fields.Float(missing=10, validate=validate_non_negative)
     token_contract_address = AddressField(required=True)
 
 
 class HomeChainSchema(ChainSchema):
     max_reorg_depth = fields.Integer(missing=10, validate=validate_non_negative)
+    event_poll_interval = fields.Float(missing=5, validate=validate_non_negative)
     gas_price = fields.Integer(missing=10 * denoms.gwei, validate=validate_non_negative)
     # disable type check as type hint in eth_utils is wrong, (see
     # https://github.com/ethereum/eth-utils/issues/168)
     minimum_validator_balance = fields.Integer(
-        missing=to_wei(0.04, "ether"),  # type: ignore
-        validate=validate_non_negative,
+        missing=to_wei(0.04, "ether"), validate=validate_non_negative  # type: ignore
     )
     balance_warn_poll_interval = fields.Float(
         missing=60, validate=validate_non_negative

--- a/tools/bridge/bridge/event_fetcher.py
+++ b/tools/bridge/bridge/event_fetcher.py
@@ -77,9 +77,6 @@ class EventFetcher:
         if from_block_number < 0:
             raise ValueError("Can not fetch events from a negative block number!")
 
-        if to_block_number > self._rpc_latest_block():
-            raise ValueError("Can not fetch events for blocks past the current head!")
-
         if from_block_number > to_block_number:
             raise ValueError("Can not fetch events for a negative range!")
 

--- a/tools/bridge/bridge/node_status.py
+++ b/tools/bridge/bridge/node_status.py
@@ -1,4 +1,5 @@
 import logging
+import time
 from typing import Dict, List, Optional
 
 import attr
@@ -17,6 +18,7 @@ class NodeStatus:
     client_version: str
     is_light_node: Optional[bool]
     block_gap: List[int]
+    timestamp: float
 
 
 def _get_node_status_parity(w3, *, client_version):
@@ -53,6 +55,7 @@ def _get_node_status_parity(w3, *, client_version):
         client_version=client_version,
         is_light_node=is_light_node,
         block_gap=block_gap,
+        timestamp=time.time(),
     )
 
 
@@ -69,6 +72,7 @@ def _get_node_status_geth(w3, *, client_version):
         client_version=client_version,
         is_light_node=None,
         block_gap=None,
+        timestamp=time.time(),
     )
 
 

--- a/tools/bridge/bridge/node_status.py
+++ b/tools/bridge/bridge/node_status.py
@@ -19,8 +19,8 @@ class NodeStatus:
     block_gap: List[int]
 
 
-def get_node_status_parity(w3):
-    client_version = w3.clientVersion
+def _get_node_status_parity(w3, *, client_version):
+    logger.debug("Fetch parity node status")
     block_number = w3.eth.blockNumber
 
     syncing_map = w3.eth.syncing or None
@@ -56,8 +56,8 @@ def get_node_status_parity(w3):
     )
 
 
-def get_node_status_geth(w3):
-    client_version = w3.clientVersion
+def _get_node_status_geth(w3, *, client_version):
+    logger.debug("Fetch geth node status")
     block_number = w3.eth.blockNumber
     syncing_map = w3.eth.syncing or None
     is_syncing = bool(syncing_map)
@@ -73,10 +73,11 @@ def get_node_status_geth(w3):
 
 
 def get_node_status(w3):
-    if w3.clientVersion.startswith("Parity"):
-        return get_node_status_parity(w3)
+    client_version = w3.clientVersion
+    if client_version.startswith("Parity"):
+        return _get_node_status_parity(w3, client_version=client_version)
     else:
-        return get_node_status_geth(w3)
+        return _get_node_status_geth(w3, client_version=client_version)
 
 
 def wait_for_node_status(w3, predicate, sleep_time=30.0):

--- a/tools/bridge/tests/test_event_fetcher.py
+++ b/tools/bridge/tests/test_event_fetcher.py
@@ -165,11 +165,6 @@ def test_fetch_events_in_range_negative_from_number(transfer_event_fetcher):
         transfer_event_fetcher.fetch_events_in_range(-1, 1)
 
 
-def test_fetch_events_in_range_to_high_to_number(transfer_event_fetcher, w3_foreign):
-    with pytest.raises(ValueError):
-        transfer_event_fetcher.fetch_events_in_range(0, w3_foreign.eth.blockNumber + 1)
-
-
 def test_fetch_events_in_range_negative_range(transfer_event_fetcher):
     with pytest.raises(ValueError):
         transfer_event_fetcher.fetch_events_in_range(1, 0)

--- a/tools/bridge/tests/test_event_fetcher.py
+++ b/tools/bridge/tests/test_event_fetcher.py
@@ -11,7 +11,8 @@ from bridge.events import ChainRole
 def fetch_all_events(fetcher: EventFetcher) -> List:
     result: List = []
     while 1:
-        events = fetcher.fetch_some_events()
+        latest_block = fetcher._rpc_get_node_status().latest_synced_block
+        events = fetcher.fetch_some_events(latest_block=latest_block)
         if not events:
             return result
         result.extend(events)

--- a/tools/bridge/tests/test_event_fetcher.py
+++ b/tools/bridge/tests/test_event_fetcher.py
@@ -11,8 +11,7 @@ from bridge.events import ChainRole
 def fetch_all_events(fetcher: EventFetcher) -> List:
     result: List = []
     while 1:
-        latest_block = fetcher._rpc_get_node_status().latest_synced_block
-        events = fetcher.fetch_some_events(latest_block=latest_block)
+        events = fetcher.fetch_some_events()
         if not events:
             return result
         result.extend(events)


### PR DESCRIPTION
Closes #576 

This should reduce the foreign node requests from daily ~150k to ~40k. 

This comes with the trade of of losing one safty check, which I think is not necessary, and
a doubled poll interval of now 10s. Because 10s is still under the 15s block time of Görli and Mainnet, this should not be a problem. 