### PR TITLE
Fix quickstart configuration for tlbc

### DIFF
--- a/tools/quickstart/quickstart/configs/tlbc/bridge-config.toml
+++ b/tools/quickstart/quickstart/configs/tlbc/bridge-config.toml
@@ -1,6 +1,6 @@
 [foreign_chain]
 rpc_url = "http://foreign-node:8545"
-token_contract_address = "0x679131f591b4f369acb8cd8c51e68596806c3916"
+token_contract_address = "0x679131F591B4f369acB8cd8c51E68596806c3916"
 bridge_contract_address = "0x18BDC736b23Ff7294BED9fa988a1443357C7B0ed"
 event_fetch_start_block_number = 8932341
 

--- a/tools/quickstart/quickstart/configs/tlbc/docker-compose.yaml
+++ b/tools/quickstart/quickstart/configs/tlbc/docker-compose.yaml
@@ -50,7 +50,6 @@ services:
       --rpcaddr 0.0.0.0
       --nousb
       --ipcdisable
-      --goerli
       --syncmode light
       --datadir /data/database
       --rpccorsdomain *


### PR DESCRIPTION
Adjust token contract address to be a checksum address.
Adjust foreign node to connect with mainnet instead of goeli.