### PR TITLE
Add 'merge release back to master' step to blockchain documentation

### DIFF
--- a/chain/README-dev.md
+++ b/chain/README-dev.md
@@ -30,3 +30,4 @@
 5. Check that the image is built and pushed to Docker Hub under
    `trustlines/tlbc-testnet:release` or
    `trustlines/tlbc-node:release`, respectively.
+6. Merge back the changes from the */release branch into master.


### PR DESCRIPTION
We've decided to merge back from the respective release branches into
master. That step has been missing.