### PR TITLE
Add validtor set contract in tlbc spec

### DIFF
--- a/chain/tlbc/tlbc-spec.json
+++ b/chain/tlbc/tlbc-spec.json
@@ -55,6 +55,9 @@
                                 "0xf176B51FDe516bCD8aab3778FBc4ac970423419e",
                                 "0xFda153D9ad9c51a5637F96C82427510bd8202847"
                             ]
+                        },
+                        "307703": {
+                            "safeContract": "0xF129765E99EC542bC49C81A9eF6C5fFF10529322"
                         }
                     }
                 },


### PR DESCRIPTION
Uses fancy block number for fork corresponding to timestamp 1576147494
which should land on the 12/12/2019 at 11:45 at a block rate of
5.49 sec per block. Uses safeContract which is the non-reporting
validator contract.

closes https://github.com/trustlines-network/project/issues/773