### PR TITLE
Add CHANGELOG files both for chains

### DIFF
--- a/chain/README-dev.md
+++ b/chain/README-dev.md
@@ -1,39 +1,112 @@
 # Developer Documentation
 
+## Branches
+
+We use `laika-node/pre-release`/`tlbc-node/pre-release` for release candidates
+and `laika-node/release`/`tlbc-node/release` for releases. We only merge from
+`master` to `*/pre-release`, from `*/pre-release` to `*/release` and from
+`*/release` back to `master`.
+
+The version on the master branch should always be a `dev` version. The
+`*/pre-release` branches should always have a `rc` version and on `*/release`
+branches we only have `prod` releases (where `prod` doesn't appear in the
+version number, i.e. the version number is always `major.minor.patch`).
+
+## bumpversion
+
+Both chains use [bumpversion](https://pypi.org/project/bumpversion/) in order to
+maintain their version. bumpversion can be used to automatically upgrade the
+current version in the respective `VERSION` file within the `chain/laika` and
+`chain/tlbc` directories.
+
+bumpversion is configured via the `.bumpversion.cfg` configuration files in
+`chain/laika` and `chain/tlbc`. If you want to run bumpversion to change
+a chain's version, please change to the chain's directory first. Note that
+bumping the version will automatically create a new commit.
+
+## Making A Pre-release
+
+Adopt the following instructions for the respective chain (demonstrated for
+the Laika test network) new version:
+
+```sh
+$ git checkout master
+$ git pull
+$ git checkout -b laika-node/prepare/pre-release-<version>
+$ cd chain/laika
+$ bumpversion release
+```
+
+and open a PR for this new branch to `laika-node/pre-release`.
+
+The version in the `*/pre-release` branches should always be a 'release candidate'
+version with the `rc` suffix.
+
+## Making A Release
+
+Run the following commands and adopt for the respective chain (demonstrated for
+the Laika test network) and new version:
+
+```sh
+$ git checkout laika-node/pre-release
+$ git pull
+$ git checkout -b laika-node/prepare/release-<version>
+$ cd chain/laika
+$ bumpversion release
+```
+
+and open a PR for this new branch to `laika-node/release`.
+
+The version in the `*/release` branches should always be a 'release' version
+with a clean version number.
+
+## Merge Release Back
+
+After a release has been made, it should been merged back to the `master`
+branch. Adopt the following instructions for the respective chain (demonstrated
+for the Laika test network) and the next version:
+
+```sh
+$ git checkout laika-node/release
+$ git pull
+$ git checkout -b laika-node/prepare/master-<next-version>
+$ cd chain/laika
+$ bumpversion path
+```
+
+and open a PR for this branch to `master`.
+
+The version in the `master` branch should always be a 'development' version with
+the `dev` suffix.
+
 ## Release Checklist
 
-0. Prerequisite: The master branch contains the version to be
-   released
-1. Open and merge a PR `master` -> `laika-node/pre-release` (for
-   testnet releases) or `master` -> `tlbc-node/pre-release` (for
-   mainnet releases) without waiting for a review. Make sure you have
-   called `bumpversion release` in the `chain/laika` or `chain/tlbc`
-   folders and the version contains the 'rc' modifier (release candidate).
-   This will built the docker image and push it to Docker Hub under
-   either `trustlines/tlbc-testnet-next:pre-release` (for testnet
-   releases) or `trustlines/tlbc-node-next:pre-release` (for mainnet
-   releases).
-2. Test the pre-release:
+**Attention:**
+Never use the `rebase and merge` functionality to finalize a PR at GitHub during
+the release process. This will create new commits and causes a different history
+for the release relevant branches.
+
+0. Prerequisite: The `master` branch contains the version to be released.
+1. Follow the instructions to [make a pre-release](#making-a-pre-release).
+   Merging this PR will build the Docker image and pushes it to Docker Hub under
+   either `trustlines/tlbc-testnet-next:pre-release` (for testnet pre-releases)
+   or `trustlines/tlbc-node-next:pre-release` (for mainnet pre-releases).
+2. Test the `pre-release` version:
    - Pull the newly built image from Docker Hub.
-   - Double check that changes to the chain spec (if any) are
-     correct.
-   - Run the node and check that it finds other peers, connects to
-     them, and starts syncing the chain.
-   - Run the node in a pre-existing environment set up using the
-     quickstart script and check that it connects to peers and
-     continues to stay at the head of the chain.
-   - Perform any additional tests compelled by the specifics of the
-     update.
-3. Bump the version with `bumpversion release` again and open a PR
-   `laika-node/pre-release` -> `laika-node/release` or
-   `tlbc-node/pre-release` -> `tlbc-node/release`.
-   Make sure the version is a production release and doesn't contain
-   the 'rc' or 'dev' modifiers. Wait for a review confirming that the
-   necessary testing steps have been performed, and merge it.
-4. Authorize the release in CircleCI
-5. Check that the CircleCI builds and pushes the image to Docker Hub
-   under `trustlines/tlbc-testnet:release` or
-   `trustlines/tlbc-node:release`, respectively.
-6. Merge back the changes from the `*/release` branch into master and
-   bump the version on the master branch. Make sure the version ends
-   up being a 'dev' version.
+   - Double check that changes to the chain spec (if any) are correct.
+   - Run the node and check that it finds other peers, connects to them, and
+     starts syncing the chain.
+   - Run the node in a pre-existing environment set up using the quickstart
+     script and check that it connects to peers and continues to stay at the
+     head of the chain.
+   - Perform any additional tests compelled by the specifics of the update.
+3. Follow the instructions to [make a release](#making-a-release).
+   Wait for a PR review confirming that the necessary testing steps have been
+   performed and merge it. This will trigger the build of the release Docker
+   image.
+4. Authorize the release of the image to Docker Hub in CircleCI.
+5. Check that CircleCI was successful and a that there is a new image under
+   `trustlines/tlbc-testnet:release` or `trustlines/tlbc-node:release`,
+   respectively.
+6. Follow the instructions to [merge the release back](#merge-release-back) to
+   `master`.

--- a/chain/laika/CHANGELOG.rst
+++ b/chain/laika/CHANGELOG.rst
@@ -1,0 +1,18 @@
+==========
+Change Log
+==========
+
+1.0.0 (2020-03-24)
+-------------------------------
+- Add fork to new validator set as fixed static JSON array at block number
+  `5_652_453`. The set includes 5 new addresses controlled by the Trustlines
+  Foundation and Brainbot Technologies. Requires no finality.
+- Add a second fork at block `5_652_553` to a validator set as contract with the
+  same address list as the fork before. This is based on the restored finality
+  by the previous fork.
+- Replace boot node list with the new 5 validators enode addresses.
+- Increase the minimum required gas price to `1GWei` in the validators node
+  configuration.
+- Explicitly set the gas target for blocks to `8_000_000` in the node validators
+  configuration.
+- Limit the transaction queue of validators to `100` transactions per sender.

--- a/chain/tlbc/CHANGELOG.rst
+++ b/chain/tlbc/CHANGELOG.rst
@@ -1,0 +1,14 @@
+==========
+Change Log
+==========
+
+1.1.0 (2019-12-09)
+-------------------------------
+- Fork to validator set based on a contract
+- Exclude validators which have not passed the initial phase after auction
+
+1.0.0 (2019-11-13)
+-------------------------------
+- Add first list of validators from the auction as static JSON array
+- Finalized version of genesis block including pre-compiled contracts
+- Define enode address list of bootstrap nodes controlled by the foundation


### PR DESCRIPTION
Closes: #615

I also attempt to improve the developer documentation for the release procedure. As I personally experienced is it not 100% clear how to use/follow it.

**Please feel free to change** anything of the contents by yourself without a change request.

One open section (for me) in `README-dev.md` is the following:
> 3. Bump the version with `bumpversion release` again and open a PR
   `laika-node/pre-release` -> `laika-node/release` or
   `tlbc-node/pre-release` -> `tlbc-node/release`.

As I understood and pointed out for the other steps, the version bumping should not happen on the "previous" branch where merged from. So after the merge from `master` to `pre-release` is another step, the version can be bumped after the PR has been excepted on `pre-release` itself. But after the PR from `pre-release` to `release` there is nothing afterwards before the release. If we want to dump the version only after the PR was merged, we **must** ignore the first build attempt by CircleCI and only authorize the second one.
This is my point of view from Bernd his explanations in the call yesterday. Please feel free to come up with better solutions or correct me if I'm wrong. Thanks for your help!