### PR TITLE
Auction deploy can now resume deployment where it stopped

### DIFF
--- a/tools/auction-deploy/tests/test_cli.py
+++ b/tools/auction-deploy/tests/test_cli.py
@@ -187,6 +187,21 @@ def test_cli_deploy_token_auction(runner):
     assert result.exit_code == 0
 
 
+def test_cli_resume_deployment(runner, contracts_not_initialized):
+    result = runner.invoke(
+        main,
+        args=f"deploy --start-price 123 --duration 4 --max-participants 567 --min-participants 456 "
+        f"--release-timestamp 2000000000 --jsonrpc test --auction {contracts_not_initialized.auction.address}"
+        f" --locker {contracts_not_initialized.locker.address}",
+    )
+
+    assert result.exit_code == 0
+    assert (
+        extract_auction_address(result.output)
+        == contracts_not_initialized.auction.address
+    )
+
+
 def test_cli_transaction_parameters_set(runner):
     result = runner.invoke(
         main,

--- a/tools/auction-deploy/tests/test_deploy.py
+++ b/tools/auction-deploy/tests/test_deploy.py
@@ -11,7 +11,7 @@ from auction_deploy.core import (
 )
 
 
-@pytest.fixture
+@pytest.fixture()
 def deployed_contracts(web3, auction_options):
 
     deployed_contracts: DeployedAuctionContracts = deploy_auction_contracts(
@@ -55,16 +55,118 @@ def test_deploy_contracts(web3, auction_options: AuctionOptions):
     assert deployed_contracts.slasher.functions.initialized().call() is False
 
 
-def test_resume_deploy_contracts(web3, auction_options, deployed_contracts):
-    deployed_contracts: DeployedAuctionContracts = deploy_auction_contracts(
-        web3=web3,
-        auction_options=auction_options,
-        already_deployed_contracts=DeployedContractsAddresses(
+@pytest.fixture(params=[True, False])
+def already_deployed_auction_address(request, deployed_contracts):
+    if request.param:
+        return deployed_contracts.auction.address
+    else:
+        return None
+
+
+@pytest.fixture(params=[True, False])
+def already_deployed_locker_address(request, deployed_contracts):
+    if request.param:
+        return deployed_contracts.locker.address
+    else:
+        return None
+
+
+@pytest.fixture(params=[True, False])
+def already_initialized_locker_contract(
+    request, deployed_contracts, use_token, token_contract
+):
+    if request.param:
+        locker_init_args = (
+            2000000000,
+            deployed_contracts.slasher.address,
+            deployed_contracts.auction.address,
+        )
+        if use_token:
+            locker_init_args += (token_contract.address,)
+        deployed_contracts.locker.functions.init(*locker_init_args).transact()
+    return deployed_contracts.locker
+
+
+@pytest.fixture(params=[True, False])
+def already_deployed_slasher_address(request, deployed_contracts):
+    if request.param:
+        return deployed_contracts.slasher.address
+    else:
+        return None
+
+
+@pytest.fixture(params=[True, False])
+def already_initialized_slasher_contract(request, deployed_contracts):
+    if request.param:
+        deployed_contracts.slasher.functions.init(
             deployed_contracts.locker.address
-        ),
+        ).transact()
+    return deployed_contracts.slasher
+
+
+@pytest.fixture()
+def already_deployed_contract_addresses(
+    already_deployed_auction_address,
+    already_deployed_locker_address,
+    already_deployed_slasher_address,
+):
+    """Returns every possible combinations of deployed / empty auction related contracts"""
+    return DeployedContractsAddresses(
+        auction=already_deployed_auction_address,
+        locker=already_deployed_locker_address,
+        slasher=already_deployed_slasher_address,
     )
 
-    assert deployed_contracts.locker.address == deployed_contracts.locker.address
+
+@pytest.fixture()
+def already_initialized_contract_addresses(
+    deployed_contracts,
+    already_initialized_locker_contract,
+    already_initialized_slasher_contract,
+):
+    """Returns every possible combinations of initialized/non-initialized auction related contracts"""
+    return DeployedAuctionContracts(
+        auction=deployed_contracts.auction,
+        locker=already_initialized_locker_contract,
+        slasher=already_initialized_slasher_contract,
+    )
+
+
+def test_resume_deploy_contracts(
+    web3, auction_options, already_deployed_contract_addresses
+):
+    if (
+        already_deployed_contract_addresses.auction is not None
+        and already_deployed_contract_addresses.locker is None
+    ):
+        with pytest.raises(ValueError):
+            deploy_auction_contracts(
+                web3=web3,
+                auction_options=auction_options,
+                already_deployed_contracts=already_deployed_contract_addresses,
+            )
+    else:
+        deployed_contracts: DeployedAuctionContracts = deploy_auction_contracts(
+            web3=web3,
+            auction_options=auction_options,
+            already_deployed_contracts=already_deployed_contract_addresses,
+        )
+
+        if already_deployed_contract_addresses.auction is not None:
+            assert (
+                deployed_contracts.auction.address
+                == already_deployed_contract_addresses.auction
+            )
+        if already_deployed_contract_addresses.locker is not None:
+            assert (
+                deployed_contracts.locker.address
+                == already_deployed_contract_addresses.locker
+            )
+        if already_deployed_contract_addresses.slasher is not None:
+            assert (
+                deployed_contracts.slasher.address
+                == already_deployed_contract_addresses.slasher
+            )
 
 
 def test_init_contracts(deployed_contracts, web3, release_timestamp, auction_options):
@@ -78,6 +180,26 @@ def test_init_contracts(deployed_contracts, web3, release_timestamp, auction_opt
 
     assert deployed_contracts.locker.functions.initialized().call() is True
     assert deployed_contracts.slasher.functions.initialized().call() is True
+
+
+def test_resume_init_contracts(
+    already_initialized_contract_addresses, web3, release_timestamp, auction_options
+):
+    initialize_auction_contracts(
+        web3=web3,
+        contracts=already_initialized_contract_addresses,
+        release_timestamp=release_timestamp,
+        token_address=auction_options.token_address,
+    )
+
+    assert (
+        already_initialized_contract_addresses.locker.functions.initialized().call()
+        is True
+    )
+    assert (
+        already_initialized_contract_addresses.slasher.functions.initialized().call()
+        is True
+    )
 
 
 def test_whitelist_addresses(deployed_contracts, whitelist, web3):

--- a/tools/auction-deploy/tests/test_deploy.py
+++ b/tools/auction-deploy/tests/test_deploy.py
@@ -3,6 +3,7 @@ import pytest
 from auction_deploy.core import (
     AuctionOptions,
     DeployedAuctionContracts,
+    DeployedContractsAddresses,
     deploy_auction_contracts,
     initialize_auction_contracts,
     missing_whitelisted_addresses,
@@ -52,6 +53,18 @@ def test_deploy_contracts(web3, auction_options: AuctionOptions):
 
     assert deployed_contracts.slasher is not None
     assert deployed_contracts.slasher.functions.initialized().call() is False
+
+
+def test_resume_deploy_contracts(web3, auction_options, deployed_contracts):
+    deployed_contracts: DeployedAuctionContracts = deploy_auction_contracts(
+        web3=web3,
+        auction_options=auction_options,
+        already_deployed_contracts=DeployedContractsAddresses(
+            deployed_contracts.locker.address
+        ),
+    )
+
+    assert deployed_contracts.locker.address == deployed_contracts.locker.address
 
 
 def test_init_contracts(deployed_contracts, web3, release_timestamp, auction_options):


### PR DESCRIPTION
Addresses of already deployed contract has to be provided via cli
If the already deployed contracts are in a state where deployment
cannot be resumed, a red message will be printed