### PR TITLE
Update tlbc chain spec for validator set after token auction

### DIFF
--- a/chain/tlbc/tlbc-spec.json
+++ b/chain/tlbc/tlbc-spec.json
@@ -58,6 +58,9 @@
                         },
                         "307703": {
                             "safeContract": "0xF129765E99EC542bC49C81A9eF6C5fFF10529322"
+                        },
+                        "3328800": {
+                            "safeContract": "0x0ae98a26Df482D5f98E0C600C1880B34D2A51132"
                         }
                     }
                 },


### PR DESCRIPTION
Release time: 1594166400
current time: 1592998270
current_block: 3,146,525

current_nr_validators: 41
active: 32
current_block_time: 5*41/32

block_delay: release_time - current_time / current_block_time
fork_block: current_block + block_delay

I subtracted 67 from the fork_block of the calculation to make it look nice, and to "ensure" at least some blocks are mined with the new validators before the deposits are released