### PR TITLE
ECDSA library for signature recovery will revert when failling

### DIFF
--- a/contracts/contracts/lib/ECDSA.sol
+++ b/contracts/contracts/lib/ECDSA.sol
@@ -50,7 +50,7 @@ library ECDSA {
 
         // Check the signature length
         if (signature.length != 65) {
-            return (address(0));
+            revert("ECDSA: invalid signature length");
         }
 
         // Divide the signature in r, s and v variables
@@ -70,10 +70,12 @@ library ECDSA {
 
         // If the version is correct return the signer address
         if (v != 27 && v != 28) {
-            return (address(0));
+            revert("ECDSA: incorrect signature version");
         } else {
             // solium-disable-next-line arg-overflow
-            return ecrecover(hash, v, r, s);
+            address signer = ecrecover(hash, v, r, s);
+            require(signer != address(0), "ECDSA: invalid signature");
+            return signer;
         }
     }
 


### PR DESCRIPTION
It was previously returning the zero address instead of
reverting when the signature was invalid