### PR TITLE
Add option --expose-ports to quickstart to expose the home node ports

### DIFF
--- a/quickstart/src/quickstart/configs/docker-compose.override.yaml
+++ b/quickstart/src/quickstart/configs/docker-compose.override.yaml
@@ -1,0 +1,10 @@
+# This file is used to optionally add a config to expose the ports of the home node
+
+version: "2.2"
+services:
+  home-node:
+    ports:
+      - 8545:8545
+      - 8545:8545/udp
+      - 8546:8546
+      - 8546:8546/udp

--- a/quickstart/src/quickstart/docker.py
+++ b/quickstart/src/quickstart/docker.py
@@ -1,4 +1,5 @@
 import filecmp
+import functools
 import os
 import shutil
 import subprocess
@@ -7,6 +8,7 @@ from textwrap import fill
 from typing import List
 
 import click
+import pkg_resources
 
 from quickstart.constants import SHARED_CHAIN_SPEC_PATH
 from quickstart.utils import (
@@ -37,6 +39,7 @@ LEGACY_CONTAINER_NAMES = [
     "quickstart_watchtower_1",
 ]
 DOCKER_COMPOSE_FILE_NAME = "docker-compose.yaml"
+DOCKER_COMPOSE_OVERRIDE_FILE_NAME = "docker-compose.override.yaml"
 
 README_PATH = "readme.txt"
 README_TEXT = "\n".join(
@@ -53,10 +56,12 @@ README_TEXT = "\n".join(
 )
 
 
-def setup_interactivaly(base_dir, docker_compose_file):
+def setup_interactivaly(base_dir, docker_compose_file, expose_node_ports):
     create_docker_readme(base_dir)
+
+    existing_docker_compose_file = os.path.join(base_dir, DOCKER_COMPOSE_FILE_NAME)
     if does_docker_compose_file_exist(base_dir) and not filecmp.cmp(
-        os.path.join(base_dir, DOCKER_COMPOSE_FILE_NAME), docker_compose_file
+        existing_docker_compose_file, docker_compose_file
     ):
         while True:
             choice = click.prompt(
@@ -87,6 +92,65 @@ def setup_interactivaly(base_dir, docker_compose_file):
             base_dir=base_dir, docker_compose_file=docker_compose_file
         )
 
+    existing_override_file = os.path.join(base_dir, DOCKER_COMPOSE_OVERRIDE_FILE_NAME)
+    default_override_file = get_docker_compose_override_file()
+    if expose_node_ports:
+        if does_docker_compose_override_file_exist(base_dir) and not filecmp.cmp(
+            existing_override_file, default_override_file
+        ):
+            while True:
+                choice = click.prompt(
+                    fill(
+                        "You already seem to have a docker compose override file. "
+                        "If you did not change it, you can safely overwrite it."
+                        "Overwrite with default (1), keep own (2), or show diff (3)?"
+                    )
+                    + "\n",
+                    type=click.Choice(("1", "2", "3")),
+                    show_choices=False,
+                )
+
+                if choice == "1":
+                    copy_default_docker_override_file(base_dir=base_dir)
+                    break
+                elif choice == "2":
+                    # Nothing to do
+                    break
+                elif choice == "3":
+                    show_override_diff(base_dir=base_dir)
+                else:
+                    assert False, "unreachable"
+        else:
+            copy_default_docker_override_file(base_dir=base_dir)
+    else:
+        if does_docker_compose_override_file_exist(base_dir) and filecmp.cmp(
+            existing_override_file, default_override_file
+        ):
+            while True:
+                click.secho(
+                    fill(
+                        "You already seem to have a default docker compose override file. "
+                        "This file is responsible for exposing the ports of the node to the local machine."
+                        "Do you want to keep the file and run the home node with exposed ports or remove it?"
+                    )
+                    + "\n",
+                    fg="red",
+                )
+                choice = click.prompt(
+                    fill("Keep the file (1) or remove it (2)?") + "\n",
+                    type=click.Choice(("1", "2")),
+                    show_choices=False,
+                )
+
+                if choice == "1":
+                    # nothing to do
+                    break
+                elif choice == "2":
+                    delete_docker_override_file(base_dir)
+                    break
+                else:
+                    assert False, "unreachable"
+
 
 def create_docker_readme(base_dir):
     if not os.path.isfile(os.path.join(base_dir, README_PATH)):
@@ -114,17 +178,17 @@ def update_and_start(
         main_docker_service_names + optional_docker_service_names + ["tlbc-monitor"]
     )
 
-    default_env_vars = {"COMPOSE_PROJECT_NAME": project_name}
+    env_variables = {"COMPOSE_PROJECT_NAME": project_name}
     if is_validator_account_prepared(base_dir):
         env_variables = {
-            **default_env_vars,
+            **env_variables,
             "ADDRESS_ARG": f"--address {get_validator_address(base_dir)}",
             "AUTHOR_ARG": f"--author {get_author_address(base_dir)}",
             "ROLE": "validator",
         }
         click.echo("\nNode will run as a validator")
     else:
-        env_variables = {**default_env_vars, "ROLE": "observer"}
+        env_variables = {**env_variables, "ROLE": "observer"}
         click.echo("\nNode will run as a non-validator")
 
     with open(os.path.join(base_dir, ".env"), mode="w") as env_file:
@@ -132,11 +196,7 @@ def update_and_start(
             f"{key}={value}\n" for (key, value) in env_variables.items()
         )
 
-    runtime_env_variables = {
-        **os.environ,
-        **env_variables,
-        "COMPOSE_FILE": os.path.join(base_dir, DOCKER_COMPOSE_FILE_NAME),
-    }
+    runtime_env_variables = {**os.environ, **env_variables}
 
     if host_base_dir is not None:
         runtime_env_variables["HOST_BASE_DIR"] = host_base_dir
@@ -148,9 +208,23 @@ def update_and_start(
         "universal_newlines": True,
     }
 
+    docker_compose_file_path = os.path.join(base_dir, DOCKER_COMPOSE_FILE_NAME)
+    docker_compose_path_option = ["-f", docker_compose_file_path]
+
+    if does_docker_compose_override_file_exist(base_dir):
+        docker_compose_override_file_path = os.path.join(
+            base_dir, DOCKER_COMPOSE_OVERRIDE_FILE_NAME
+        )
+        docker_compose_path_option += ["-f", docker_compose_override_file_path]
+
     try:
         click.echo("Shutting down possibly remaining docker services first...")
-        subprocess.run(["docker-compose", "down"], check=True, **run_kwargs)
+        subprocess.run(
+            ["docker-compose", *docker_compose_path_option, "down"],
+            check=True,
+            **run_kwargs,
+        )
+
         for container_name in LEGACY_CONTAINER_NAMES:
             # use check=False as docker stop and docker rm fail if the container does not exist
             subprocess.run(
@@ -160,15 +234,20 @@ def update_and_start(
 
         click.echo("Pulling recent Docker image versions...")
         subprocess.run(
-            ["docker-compose", "pull"] + all_docker_service_names,
+            ["docker-compose", *docker_compose_path_option, "pull"]
+            + all_docker_service_names,
             check=True,
             **run_kwargs,
         )
 
         click.echo("Starting Docker services...")
-        subprocess.run(["docker-compose", "up", "--no-start"], check=True, **run_kwargs)
         subprocess.run(
-            ["docker-compose", "start"]
+            ["docker-compose", *docker_compose_path_option, "up", "--no-start"],
+            check=True,
+            **run_kwargs,
+        )
+        subprocess.run(
+            ["docker-compose", *docker_compose_path_option, "start"]
             + main_docker_service_names
             + optional_docker_service_names,
             check=True,
@@ -178,7 +257,9 @@ def update_and_start(
         wait_for_chain_spec(base_dir)
 
         subprocess.run(
-            ["docker-compose", "start", "tlbc-monitor"], check=True, **run_kwargs
+            ["docker-compose", *docker_compose_path_option, "start", "tlbc-monitor"],
+            check=True,
+            **run_kwargs,
         )
 
     except subprocess.CalledProcessError as called_process_error:
@@ -230,6 +311,10 @@ def does_docker_compose_file_exist(base_dir):
     return os.path.isfile(os.path.join(base_dir, DOCKER_COMPOSE_FILE_NAME))
 
 
+def does_docker_compose_override_file_exist(base_dir):
+    return os.path.isfile(os.path.join(base_dir, DOCKER_COMPOSE_OVERRIDE_FILE_NAME))
+
+
 def copy_default_docker_file(base_dir, docker_compose_file):
     if not os.path.isfile(docker_compose_file):
         raise click.ClickException(
@@ -243,9 +328,47 @@ def copy_default_docker_file(base_dir, docker_compose_file):
     )
 
 
+def copy_default_docker_override_file(base_dir):
+    docker_compose_override_file = get_docker_compose_override_file()
+    if not os.path.isfile(docker_compose_override_file):
+        raise click.ClickException(
+            "\n"
+            + fill(
+                f"Expecting a docker-compose override configuration file at {docker_compose_override_file}"
+            )
+        )
+    shutil.copyfile(
+        docker_compose_override_file,
+        os.path.join(base_dir, DOCKER_COMPOSE_OVERRIDE_FILE_NAME),
+    )
+
+
+def delete_docker_override_file(base_dir):
+    path = os.path.join(base_dir, DOCKER_COMPOSE_OVERRIDE_FILE_NAME)
+    if not os.path.isfile(path):
+        raise ValueError(f"Expected to have a file at path: {path}")
+    os.remove(path)
+
+
 def show_diff(base_dir, docker_compose_file):
     show_file_diff(
         os.path.join(base_dir, DOCKER_COMPOSE_FILE_NAME),
         docker_compose_file,
         file_name=DOCKER_COMPOSE_FILE_NAME,
     )
+
+
+def show_override_diff(base_dir):
+    show_file_diff(
+        os.path.join(base_dir, DOCKER_COMPOSE_OVERRIDE_FILE_NAME),
+        get_docker_compose_override_file(),
+        file_name=DOCKER_COMPOSE_OVERRIDE_FILE_NAME,
+    )
+
+
+def get_docker_compose_override_file():
+    return functools.partial(
+        pkg_resources.resource_filename,
+        __name__,
+        f"configs/{DOCKER_COMPOSE_OVERRIDE_FILE_NAME}",
+    )()

--- a/quickstart/src/quickstart/netstats.py
+++ b/quickstart/src/quickstart/netstats.py
@@ -58,7 +58,7 @@ def setup_interactively(base_dir, netstats_url) -> None:
 
     if not click.confirm(
         fill(
-            "Have you already received your credentials and do you want to set up the netstats client now?"
+            "Have you already received your credentials and do you want to set up the netstats client now?\n"
         )
     ):
         # Necessary to make docker-compose not complaining about it.


### PR DESCRIPTION
close: https://github.com/trustlines-network/project/issues/881

It is a slight pain to test.

The quickstart script does not work on master, since it pulls the latest released docker image for the home node, and that image does not use Openethereum, while the docker-compose file expects the version with Openethereum. This is to keep the repository coherent over functional.

To test this, you thus need to build the home node image you want to test (laika or tlbc) on master and tagging it the way the docker-compose file expects it. e.g. `cd chain && docker build -f tlbc/Dockerfile -t trustlines/tlbc-node:release .`.

You then need to prevent the quickstart script to pull the image and replace it by commenting lines 233-239 of `quickstart/src/quickstart/docker.py`.

After that you are free to test whatever you want, for example `quickstart tlbc --expose-ports` and test that the home node is reachable with `curl --data '{"method":"eth_blockNumber","params":[],"id":1,"jsonrpc":"2.0"}' -H "Content-Type: application/json" -X POST localhost:8545`.